### PR TITLE
Tentative fix for STOR-738

### DIFF
--- a/src/main/java/org/italiangrid/storm/webdav/error/SameFileError.java
+++ b/src/main/java/org/italiangrid/storm/webdav/error/SameFileError.java
@@ -16,26 +16,26 @@
 package org.italiangrid.storm.webdav.error;
 
 
-public class SameFileCopyError extends StoRMWebDAVError {
+public class SameFileError extends StoRMWebDAVError {
 
   /**
    * 
    */
   private static final long serialVersionUID = 1503156218876662642L;
 
-  public SameFileCopyError(String message) {
+  public SameFileError(String message) {
 
     super(message);
 
   }
 
-  public SameFileCopyError(Throwable cause) {
+  public SameFileError(Throwable cause) {
 
     super(cause);
 
   }
 
-  public SameFileCopyError(String message, Throwable cause) {
+  public SameFileError(String message, Throwable cause) {
 
     super(message, cause);
 

--- a/src/main/java/org/italiangrid/storm/webdav/fs/DefaultFSStrategy.java
+++ b/src/main/java/org/italiangrid/storm/webdav/fs/DefaultFSStrategy.java
@@ -80,6 +80,7 @@ public class DefaultFSStrategy implements FilesystemAccess {
         throw new SameFileError("Source and destination files are the same");
       }
       
+      // Overwrites the destination, if it exists 
       Files.move(source, dest);
 
     } catch (IOException e) {

--- a/src/main/java/org/italiangrid/storm/webdav/fs/DefaultFSStrategy.java
+++ b/src/main/java/org/italiangrid/storm/webdav/fs/DefaultFSStrategy.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.italiangrid.storm.webdav.checksum.Adler32ChecksumInputStream;
-import org.italiangrid.storm.webdav.error.SameFileCopyError;
+import org.italiangrid.storm.webdav.error.SameFileError;
 import org.italiangrid.storm.webdav.error.StoRMWebDAVError;
 import org.italiangrid.storm.webdav.fs.attrs.ExtendedAttributesHelper;
 import org.slf4j.Logger;
@@ -73,8 +73,13 @@ public class DefaultFSStrategy implements FilesystemAccess {
 
     LOG.debug("mv: source={}, dest={}", source.getAbsolutePath(),
       dest.getAbsolutePath());
+    
     try {
 
+      if (source.getCanonicalPath().equals(dest.getCanonicalPath())) {
+        throw new SameFileError("Source and destination files are the same");
+      }
+      
       Files.move(source, dest);
 
     } catch (IOException e) {
@@ -99,7 +104,7 @@ public class DefaultFSStrategy implements FilesystemAccess {
     try {
       
       if (source.getCanonicalPath().equals(dest.getCanonicalPath())) {
-        throw new SameFileCopyError("Source and destination URIs are the same");
+        throw new SameFileError("Source and destination files are the same");
       }
 
       if (source.isDirectory()) {

--- a/src/main/java/org/italiangrid/storm/webdav/milton/StoRMHTTPManagerBuilder.java
+++ b/src/main/java/org/italiangrid/storm/webdav/milton/StoRMHTTPManagerBuilder.java
@@ -17,7 +17,9 @@ package org.italiangrid.storm.webdav.milton;
 
 import io.milton.config.HttpManagerBuilder;
 import io.milton.http.AuthenticationHandler;
+import io.milton.http.Handler;
 import io.milton.http.http11.DefaultHttp11ResponseHandler.BUFFERING;
+import io.milton.http.webdav.MoveHandler;
 
 import com.google.common.collect.ImmutableList;
 
@@ -44,4 +46,20 @@ public class StoRMHTTPManagerBuilder extends HttpManagerBuilder {
 
   }
 
+  @Override
+  protected void afterInit() {
+
+    super.afterInit();
+    disableDeleteExistingBeforeMoveInMoveHandler();
+  }
+
+  
+  private void disableDeleteExistingBeforeMoveInMoveHandler() {
+
+    for (Handler h : getWebDavProtocol().getHandlers()) {
+      if (h instanceof MoveHandler) {
+        ((MoveHandler) h).setDeleteExistingBeforeMove(false);
+      }
+    }
+  }
 }

--- a/src/main/java/org/italiangrid/storm/webdav/milton/StoRMMiltonBehaviour.java
+++ b/src/main/java/org/italiangrid/storm/webdav/milton/StoRMMiltonBehaviour.java
@@ -24,7 +24,7 @@ import io.milton.http.Response;
 import io.milton.http.http11.Http11ResponseHandler;
 
 import org.italiangrid.storm.webdav.error.ResourceNotFound;
-import org.italiangrid.storm.webdav.error.SameFileCopyError;
+import org.italiangrid.storm.webdav.error.SameFileError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class StoRMMiltonBehaviour implements Filter {
       }
     } catch (ResourceNotFound e) {
       responseHandler.respondNotFound(response, request);
-    } catch (SameFileCopyError e) {
+    } catch (SameFileError e) {
       responseHandler.respondForbidden(null, response, request);
 
     } catch (Throwable t) {

--- a/src/main/java/org/italiangrid/storm/webdav/milton/StoRMResource.java
+++ b/src/main/java/org/italiangrid/storm/webdav/milton/StoRMResource.java
@@ -27,8 +27,11 @@ import io.milton.resource.PropFindableResource;
 import io.milton.resource.Resource;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Date;
 
+import org.italiangrid.storm.webdav.error.SameFileError;
+import org.italiangrid.storm.webdav.error.StoRMWebDAVError;
 import org.italiangrid.storm.webdav.fs.FilesystemAccess;
 import org.italiangrid.storm.webdav.fs.attrs.ExtendedAttributesHelper;
 
@@ -37,7 +40,7 @@ public abstract class StoRMResource implements Resource, PropFindableResource,
 
   protected final StoRMResourceFactory resourceFactory;
   protected final File file;
-  
+
   public StoRMResource(StoRMResourceFactory factory, File f) {
 
     resourceFactory = factory;


### PR DESCRIPTION
Previously storm-webdav raised an exception that resulted in a 500 http
status when trying to move a file over itself. While harmless in
practice, a 403 should be returned in this case, according to the webdav
spec.

The problem is that Milton does not check for identical source and
destination URIs in a MOVE, so the check must be done in the underlying
code. Moreover, Milton proactively removes the destination URI before
doing the move if the user is authorized and the Overwrite header is set
to T, so what happens is that a move of a file over itself results in a
delete in practice.

Fortunately, the removal of  the destination resource before doing the
move can be disabled setting a flag in the the Milton's MoveHandler
code. This flag cannot be easily set through the builder, so we plug in
(in an hackish way) right after the webdav protocol initialization.