### PR TITLE
Ensure adler32 checksums are always 8 chars long

### DIFF
--- a/src/main/java/org/italiangrid/storm/webdav/checksum/Adler32ChecksumInputStream.java
+++ b/src/main/java/org/italiangrid/storm/webdav/checksum/Adler32ChecksumInputStream.java
@@ -27,8 +27,11 @@ public class Adler32ChecksumInputStream extends CheckedInputStream {
   }
 
   public String getChecksumValue() {
+    return formatChecksumValue(Long.toHexString(getChecksum().getValue()));
+  }
 
-    return Long.toHexString(getChecksum().getValue());
+  private String formatChecksumValue(String checksum) {
+    return ("00000000" + checksum).substring(checksum.length());
   }
 
 }

--- a/src/main/java/org/italiangrid/storm/webdav/checksum/Adler32ChecksumOutputStream.java
+++ b/src/main/java/org/italiangrid/storm/webdav/checksum/Adler32ChecksumOutputStream.java
@@ -26,7 +26,11 @@ public class Adler32ChecksumOutputStream extends CheckedOutputStream {
   }
   
   public String getChecksumValue() {
-    return Long.toHexString(getChecksum().getValue());
+    return formatChecksumValue(Long.toHexString(getChecksum().getValue()));
+  }
+
+  private String formatChecksumValue(String checksum) {
+    return ("00000000" + checksum).substring(checksum.length());
   }
 
 }


### PR DESCRIPTION
 - Added function to add leading "0"s if
   checksum HEX is smaller than 8 chars long

   Fix: https://issues.infn.it/jira/browse/STOR-1396