### PR TITLE
Fix caching of remote JWK sets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
     <!-- Keep this aligned with the spring.boot-version property below! -->
-    <version>2.7.17</version>
+    <version>2.7.18</version>
     <relativePath />
   </parent>
 
@@ -32,14 +32,13 @@
     <java.version>17</java.version>
 
     <!-- Keep this aligned with the parent project version! -->
-    <spring-boot.version>2.7.17</spring-boot.version>
+    <spring-boot.version>2.7.18</spring-boot.version>
 
     <!-- Sonarcloud.io properties -->
     <sonar.projectKey>italiangrid_storm-webdav</sonar.projectKey>
     <sonar.organization>italiangrid</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-    <jetty-utils.version>0.4.6.v20220506</jetty-utils.version>
     <milton.version>2.7.1.7</milton.version>
 
     <commons-lang.version>2.3</commons-lang.version>
@@ -58,6 +57,7 @@
     <nimbus-jose-jwt.version>6.0.2</nimbus-jose-jwt.version>
     <mock-server.version>5.5.1</mock-server.version>
     <bouncycastle.version>1.76</bouncycastle.version>
+    <voms-api-java.version>3.3.2</voms-api-java.version>
 
     <start-class>org.italiangrid.storm.webdav.WebdavService</start-class>
 
@@ -349,34 +349,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.italiangrid</groupId>
-      <artifactId>jetty-utils</artifactId>
-      <version>${jetty-utils.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>activation</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.mail</groupId>
-          <artifactId>mail</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.jetty.aggregate</groupId>
-          <artifactId>jetty-all</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
@@ -387,7 +359,6 @@
       <artifactId>bcprov-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>
-
 
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -418,6 +389,34 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-alpn-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-alpn-conscrypt-server</artifactId>
     </dependency>
 
     <dependency>
@@ -461,6 +460,12 @@
       <groupId>io.milton</groupId>
       <artifactId>milton-api</artifactId>
       <version>${milton.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.italiangrid</groupId>
+      <artifactId>voms-api-java</artifactId>
+      <version>${voms-api-java.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
     <owner-config.version>1.0.5.1</owner-config.version>
 
     <spring-security-oauth2.version>2.3.3.RELEASE</spring-security-oauth2.version>
-    <nimbus-jose-jwt.version>6.0.2</nimbus-jose-jwt.version>
     <mock-server.version>5.5.1</mock-server.version>
     <bouncycastle.version>1.76</bouncycastle.version>
     <voms-api-java.version>3.3.2</voms-api-java.version>

--- a/src/main/java/org/italiangrid/storm/webdav/config/OAuthProperties.java
+++ b/src/main/java/org/italiangrid/storm/webdav/config/OAuthProperties.java
@@ -96,6 +96,9 @@ public class OAuthProperties {
   @Min(value = 1, message = "The refresh period must be a positive integer")
   int refreshPeriodMinutes = 60;
 
+  @Min(value = 1, message = "The refresh timeout must be a positive integer")
+  int refreshTimeoutSeconds = 30;
+
   public List<AuthorizationServer> getIssuers() {
     return issuers;
   }
@@ -110,6 +113,14 @@ public class OAuthProperties {
 
   public void setRefreshPeriodMinutes(int refreshPeriodMinutes) {
     this.refreshPeriodMinutes = refreshPeriodMinutes;
+  }
+
+  public int getRefreshTimeoutSeconds() {
+    return refreshTimeoutSeconds;
+  }
+
+  public void setRefreshTimeoutSeconds(int refreshTimeoutSeconds) {
+    this.refreshTimeoutSeconds = refreshTimeoutSeconds;
   }
 
   public void setEnableOidc(boolean enableOidc) {

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/utils/DefaultOidcConfigurationFetcher.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/utils/DefaultOidcConfigurationFetcher.java
@@ -18,17 +18,24 @@ package org.italiangrid.storm.webdav.oauth.utils;
 import static java.lang.String.format;
 
 import java.net.URI;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Map;
 
+import org.italiangrid.storm.webdav.config.OAuthProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import com.nimbusds.jose.RemoteKeySourceException;
 
 @Service
 public class DefaultOidcConfigurationFetcher implements OidcConfigurationFetcher {
@@ -39,13 +46,17 @@ public class DefaultOidcConfigurationFetcher implements OidcConfigurationFetcher
   public static final String NO_JWKS_URI_ERROR_TEMPLATE = 
       "No jwks_uri found in metadata for issuer '%s'";
 
+  private static final MediaType APPLICATION_JWK_SET_JSON = new MediaType("application", "jwk-set+json");
+
   public static final Logger LOG = LoggerFactory.getLogger(DefaultOidcConfigurationFetcher.class);
 
   final RestTemplateBuilder restBuilder;
+  final OAuthProperties oAuthProperties;
 
-  @Autowired
-  public DefaultOidcConfigurationFetcher(RestTemplateBuilder restBuilder) {
+  public DefaultOidcConfigurationFetcher(RestTemplateBuilder restBuilder,
+      OAuthProperties oAuthProperties) {
     this.restBuilder = restBuilder;
+    this.oAuthProperties = oAuthProperties;
   }
 
   private void metadataChecks(String issuer, Map<String, Object> oidcConfiguration) {
@@ -93,6 +104,34 @@ public class DefaultOidcConfigurationFetcher implements OidcConfigurationFetcher
 
       throw new OidcConfigurationResolutionError(errorMsg, e);
     }
+  }
+
+  @Override
+  public String loadJWKSourceForURL(URI uri) throws RemoteKeySourceException {
+
+    LOG.debug("Fetching JWK from {}", uri);
+
+    final Duration TIMEOUT = Duration.ofSeconds(oAuthProperties.getRefreshTimeoutSeconds());
+    RestTemplate rest = restBuilder.setConnectTimeout(TIMEOUT).setReadTimeout(TIMEOUT).build();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON, APPLICATION_JWK_SET_JSON));
+    ResponseEntity<String> response = null;
+    try {
+      RequestEntity<Void> request = RequestEntity.get(uri).headers(headers).build();
+      response = rest.exchange(request, String.class);
+      if (response.getStatusCodeValue() != 200) {
+        throw new RuntimeException(format("Received status code: %s", response.getStatusCodeValue()));
+      }
+    } catch (RuntimeException e) {
+      final String errorMsg = format("Unable to get JWK from '%s'", uri);
+      if (LOG.isDebugEnabled()) {
+        LOG.error("{}: {}", errorMsg, e.getMessage());
+      }
+      throw new RemoteKeySourceException(errorMsg, e);
+    }
+
+    return response.getBody();
   }
 
 }

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/utils/DefaultOidcConfigurationFetcher.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/utils/DefaultOidcConfigurationFetcher.java
@@ -43,20 +43,20 @@ public class DefaultOidcConfigurationFetcher implements OidcConfigurationFetcher
   public static final String WELL_KNOWN_FRAGMENT = "/.well-known/openid-configuration";
   public static final String ISSUER_MISMATCH_ERROR_TEMPLATE =
       "Issuer in metadata '%s' does not match with requested issuer '%s'";
-  public static final String NO_JWKS_URI_ERROR_TEMPLATE = 
+  public static final String NO_JWKS_URI_ERROR_TEMPLATE =
       "No jwks_uri found in metadata for issuer '%s'";
 
-  private static final MediaType APPLICATION_JWK_SET_JSON = new MediaType("application", "jwk-set+json");
+  private static final MediaType APPLICATION_JWK_SET_JSON =
+      new MediaType("application", "jwk-set+json");
 
   public static final Logger LOG = LoggerFactory.getLogger(DefaultOidcConfigurationFetcher.class);
 
-  final RestTemplateBuilder restBuilder;
-  final OAuthProperties oAuthProperties;
+  final RestTemplate restTemplate;
 
   public DefaultOidcConfigurationFetcher(RestTemplateBuilder restBuilder,
       OAuthProperties oAuthProperties) {
-    this.restBuilder = restBuilder;
-    this.oAuthProperties = oAuthProperties;
+    final Duration TIMEOUT = Duration.ofSeconds(oAuthProperties.getRefreshTimeoutSeconds());
+    this.restTemplate = restBuilder.setConnectTimeout(TIMEOUT).setReadTimeout(TIMEOUT).build();
   }
 
   private void metadataChecks(String issuer, Map<String, Object> oidcConfiguration) {
@@ -70,29 +70,27 @@ public class DefaultOidcConfigurationFetcher implements OidcConfigurationFetcher
       throw new OidcConfigurationResolutionError(
           format(ISSUER_MISMATCH_ERROR_TEMPLATE, metadataIssuer, issuer));
     }
-    
+
     if (!oidcConfiguration.containsKey("jwks_uri")) {
-      throw new OidcConfigurationResolutionError(format(NO_JWKS_URI_ERROR_TEMPLATE,issuer));
+      throw new OidcConfigurationResolutionError(format(NO_JWKS_URI_ERROR_TEMPLATE, issuer));
     }
   }
 
   @Override
   public Map<String, Object> loadConfigurationForIssuer(String issuer) {
     LOG.debug("Fetching OpenID configuration for {}", issuer);
-    
+
     ParameterizedTypeReference<Map<String, Object>> typeReference =
         new ParameterizedTypeReference<Map<String, Object>>() {};
-
-    RestTemplate rest = restBuilder.build();
 
     URI uri = UriComponentsBuilder.fromUriString(issuer + WELL_KNOWN_FRAGMENT).build().toUri();
 
     try {
 
       RequestEntity<Void> request = RequestEntity.get(uri).build();
-      Map<String, Object> conf = rest.exchange(request, typeReference).getBody();
+      Map<String, Object> conf = restTemplate.exchange(request, typeReference).getBody();
       metadataChecks(issuer, conf);
-      return conf; 
+      return conf;
     } catch (RuntimeException e) {
       final String errorMsg =
           format("Unable to resolve OpenID configuration for issuer '%s' from '%s': %s", issuer,
@@ -111,17 +109,15 @@ public class DefaultOidcConfigurationFetcher implements OidcConfigurationFetcher
 
     LOG.debug("Fetching JWK from {}", uri);
 
-    final Duration TIMEOUT = Duration.ofSeconds(oAuthProperties.getRefreshTimeoutSeconds());
-    RestTemplate rest = restBuilder.setConnectTimeout(TIMEOUT).setReadTimeout(TIMEOUT).build();
-
     HttpHeaders headers = new HttpHeaders();
     headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON, APPLICATION_JWK_SET_JSON));
     ResponseEntity<String> response = null;
     try {
       RequestEntity<Void> request = RequestEntity.get(uri).headers(headers).build();
-      response = rest.exchange(request, String.class);
+      response = restTemplate.exchange(request, String.class);
       if (response.getStatusCodeValue() != 200) {
-        throw new RuntimeException(format("Received status code: %s", response.getStatusCodeValue()));
+        throw new RuntimeException(
+            format("Received status code: %s", response.getStatusCodeValue()));
       }
     } catch (RuntimeException e) {
       final String errorMsg = format("Unable to get JWK from '%s'", uri);

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/utils/NoExpirationStringCache.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/utils/NoExpirationStringCache.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2014-2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.italiangrid.storm.webdav.oauth.utils;
+
+import java.util.concurrent.Callable;
+
+import org.springframework.cache.support.AbstractValueAdaptingCache;
+import org.springframework.lang.Nullable;
+
+public class NoExpirationStringCache extends AbstractValueAdaptingCache {
+
+  private static final String NAME = "NoExpirationCache";
+  private final String value;
+
+  public NoExpirationStringCache(String value) {
+    super(false);
+    this.value = value;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public Object getNativeCache() {
+    return this;
+  }
+
+  @Override
+  @Nullable
+  protected Object lookup(Object key) {
+      return value;
+  }
+
+  @Override
+  public void put(Object key, Object value) {
+    return;
+  }
+
+  @Override
+  public void evict(Object key) {
+    return;
+  }
+
+  @Override
+  public void clear() {
+    return;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T get(Object key, Callable<T> valueLoader) {
+    return (T) fromStoreValue(value);
+  }
+}

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/utils/OidcConfigurationFetcher.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/utils/OidcConfigurationFetcher.java
@@ -15,10 +15,15 @@
  */
 package org.italiangrid.storm.webdav.oauth.utils;
 
+import java.net.URI;
 import java.util.Map;
+
+import com.nimbusds.jose.RemoteKeySourceException;
 
 public interface OidcConfigurationFetcher {
 
   Map<String, Object> loadConfigurationForIssuer(String issuer);
+
+  String loadJWKSourceForURL(URI uri) throws RemoteKeySourceException;
 
 }

--- a/src/main/java/org/italiangrid/storm/webdav/server/DefaultJettyServerCustomizer.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/DefaultJettyServerCustomizer.java
@@ -32,7 +32,7 @@ import org.italiangrid.storm.webdav.config.ConfigurationLogger;
 import org.italiangrid.storm.webdav.config.ServiceConfiguration;
 import org.italiangrid.storm.webdav.config.ServiceConfigurationProperties;
 import org.italiangrid.storm.webdav.config.StorageAreaConfiguration;
-import org.italiangrid.utils.jetty.TLSServerConnectorBuilder;
+import org.italiangrid.storm.webdav.server.util.TLSServerConnectorBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.web.ServerProperties;

--- a/src/main/java/org/italiangrid/storm/webdav/server/DefaultWebServerFactory.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/DefaultWebServerFactory.java
@@ -16,7 +16,7 @@
 package org.italiangrid.storm.webdav.server;
 
 import org.italiangrid.storm.webdav.config.ServiceConfiguration;
-import org.italiangrid.utils.jetty.ThreadPoolBuilder;
+import org.italiangrid.storm.webdav.server.util.ThreadPoolBuilder;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer;
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;

--- a/src/main/java/org/italiangrid/storm/webdav/server/util/TLSConnectorBuilderError.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/util/TLSConnectorBuilderError.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2012-2019.
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2014-2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/italiangrid/storm/webdav/server/util/TLSConnectorBuilderError.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/util/TLSConnectorBuilderError.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2012-2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.italiangrid.storm.webdav.server.util;
+
+public class TLSConnectorBuilderError extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public TLSConnectorBuilderError(Throwable cause) {
+    super(cause);
+  }
+
+  public TLSConnectorBuilderError(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TLSConnectorBuilderError(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/org/italiangrid/storm/webdav/server/util/TLSServerConnectorBuilder.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/util/TLSServerConnectorBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2012-2019.
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2014-2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/italiangrid/storm/webdav/server/util/TLSServerConnectorBuilder.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/util/TLSServerConnectorBuilder.java
@@ -1,0 +1,662 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2012-2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.italiangrid.storm.webdav.server.util;
+
+import static java.util.Objects.isNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Security;
+import java.security.cert.CertificateException;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.conscrypt.OpenSSLProvider;
+import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http2.HTTP2Cipher;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jetty9.InstrumentedConnectionFactory;
+
+import eu.emi.security.authn.x509.X509CertChainValidatorExt;
+import eu.emi.security.authn.x509.helpers.ssl.SSLTrustManager;
+import eu.emi.security.authn.x509.impl.PEMCredential;
+
+/**
+ * A builder that configures a Jetty server TLS connector integrated with CANL
+ * {@link X509CertChainValidatorExt} certificate validation services.
+ * 
+ */
+public class TLSServerConnectorBuilder {
+
+  /**
+   * Conscrypt provider name.
+   */
+  public static final String CONSCRYPT_PROVIDER = "Conscrypt";
+
+  /**
+   * Default service certificate file.
+   */
+  public static final String DEFAULT_CERTIFICATE_FILE = "/etc/grid-security/hostcert.pem";
+
+  /**
+   * Default service certificate private key file.
+   */
+  public static final String DEFAULT_CERTIFICATE_KEY_FILE = "/etc/grid-security/hostcert.pem";
+
+  /**
+   * The port for this connector.
+   */
+  private int port;
+
+  /**
+   * The certificate file location.
+   */
+  private String certificateFile = DEFAULT_CERTIFICATE_FILE;
+
+  /**
+   * The certificate private key file location.
+   */
+  private String certificateKeyFile = DEFAULT_CERTIFICATE_KEY_FILE;
+
+  /**
+   * The password to decrypt the certificate private key file.
+   */
+  private char[] certicateKeyPassword = null;
+
+  /**
+   * The certificate validator used by this connector builder.
+   */
+  private final X509CertChainValidatorExt certificateValidator;
+
+  /**
+   * Whether client auth will be required for this connector.
+   */
+  private boolean tlsNeedClientAuth = false;
+
+  /**
+   * Whether cluent auth is supported for this connector.
+   */
+  private boolean tlsWantClientAuth = true;
+
+  /**
+   * Supported SSL protocols.
+   */
+  private String[] includeProtocols;
+
+  /**
+   * Disabled SSL protocols.
+   */
+  private String[] excludeProtocols;
+
+  /**
+   * Supported cipher suites.
+   */
+  private String[] includeCipherSuites;
+
+  /**
+   * Disabled cipher suites.
+   */
+  private String[] excludeCipherSuites;
+
+  /**
+   * The HTTP configuration for the connector being created.
+   */
+  private HttpConfiguration httpConfiguration;
+
+  /**
+   * The key manager to use for the connector being created.
+   */
+  private KeyManager keyManager;
+
+  /**
+   * The server for which the connector is being created.
+   */
+  private final Server server;
+
+  /**
+   * The metric name to associate to the connector being built.
+   */
+  private String metricName;
+
+  /**
+   * The metric registry.
+   */
+  private MetricRegistry registry;
+
+  /**
+   * Whether the Conscrypt provider should be used instead of the default JSSE implementation
+   */
+  private boolean useConscrypt = false;
+
+
+  /**
+   * Whether HTTP/2 should be configured
+   */
+  private boolean enableHttp2 = false;
+
+  /**
+   * Which TLS protocol string should be used
+   */
+  private String tlsProtocol = "TLSv1.2";
+
+  /**
+   * Custom TLS hostname verifier
+   */
+  private HostnameVerifier hostnameVerifier = null;
+
+  /**
+   * Disable JSSE hostname verification
+   */
+  private boolean disableJsseHostnameVerification = false;
+
+  /**
+   * Number of acceptors threads for the connector
+   */
+  private int acceptors = -1;
+
+  /**
+   * Number of selector threads for the connector
+   */
+  private int selectors = -1;
+
+  /**
+   * Returns an instance of the {@link TLSServerConnectorBuilder}.
+   * 
+   * @param s the {@link Server} for which the connector is being created
+   * @param certificateValidator a {@link X509CertChainValidatorExt} used to validate certificates
+   * @return an instance of the {@link TLSServerConnectorBuilder}
+   */
+  public static TLSServerConnectorBuilder instance(Server s,
+      X509CertChainValidatorExt certificateValidator) {
+
+    return new TLSServerConnectorBuilder(s, certificateValidator);
+  }
+
+  /**
+   * Private ctor.
+   * 
+   * @param s the {@link Server} for which the connector is being created
+   * @param certificateValidator a {@link X509CertChainValidatorExt} used to validate certificates
+   */
+  private TLSServerConnectorBuilder(Server s, X509CertChainValidatorExt certificateValidator) {
+
+    if (s == null) {
+      throw new IllegalArgumentException("Server cannot be null");
+    }
+
+    if (certificateValidator == null) {
+      throw new IllegalArgumentException("certificateValidator cannot be null");
+    }
+
+    this.server = s;
+    this.certificateValidator = certificateValidator;
+  }
+
+  private void credentialsSanityChecks() {
+
+    checkFileExistsAndIsReadable(new File(certificateFile), "Error accessing certificate file");
+
+    checkFileExistsAndIsReadable(new File(certificateKeyFile),
+        "Error accessing certificate key file");
+
+  }
+
+  private void loadCredentials() {
+
+    credentialsSanityChecks();
+
+    PEMCredential serviceCredentials = null;
+
+    try {
+
+      serviceCredentials =
+          new PEMCredential(certificateKeyFile, certificateFile, certicateKeyPassword);
+
+    } catch (KeyStoreException | CertificateException | IOException e) {
+
+      throw new TLSConnectorBuilderError("Error setting up service credentials", e);
+    }
+
+    keyManager = serviceCredentials.getKeyManager();
+  }
+
+  /**
+   * Configures SSL session parameters for the jetty {@link SslContextFactory}.
+   * 
+   * @param contextFactory the {@link SslContextFactory} being configured
+   */
+  private void configureContextFactory(SslContextFactory.Server contextFactory) {
+
+    if (excludeProtocols != null) {
+      contextFactory.setExcludeProtocols(excludeProtocols);
+    }
+
+    if (includeProtocols != null) {
+      contextFactory.setIncludeProtocols(includeProtocols);
+    }
+
+    if (excludeCipherSuites != null) {
+      contextFactory.setExcludeCipherSuites(excludeCipherSuites);
+    }
+
+    if (includeCipherSuites != null) {
+      contextFactory.setIncludeCipherSuites(includeCipherSuites);
+    }
+
+    contextFactory.setWantClientAuth(tlsWantClientAuth);
+    contextFactory.setNeedClientAuth(tlsNeedClientAuth);
+
+    if (useConscrypt) {
+      contextFactory.setProvider(CONSCRYPT_PROVIDER);
+    } else {
+      contextFactory.setProvider(BouncyCastleProvider.PROVIDER_NAME);
+    }
+
+    if (hostnameVerifier != null) {
+      contextFactory.setHostnameVerifier(hostnameVerifier);
+    }
+
+    if (disableJsseHostnameVerification) {
+      contextFactory.setEndpointIdentificationAlgorithm(null);
+    }
+
+  }
+
+  /**
+   * Builds a default {@link HttpConfiguration} for the TLS-enabled connector being created
+   * 
+   * @return the default {@link HttpConfiguration}
+   */
+  private HttpConfiguration defaultHttpConfiguration() {
+
+    HttpConfiguration httpsConfig = new HttpConfiguration();
+
+    httpsConfig.setSecureScheme("https");
+
+    httpsConfig.setSecurePort(port);
+
+    httpsConfig.setOutputBufferSize(32768);
+    httpsConfig.setRequestHeaderSize(8192);
+    httpsConfig.setResponseHeaderSize(8192);
+
+    httpsConfig.setSendServerVersion(true);
+    httpsConfig.setSendDateHeader(false);
+
+    httpsConfig.addCustomizer(new SecureRequestCustomizer());
+
+    return httpsConfig;
+
+  }
+
+  /**
+   * Gives access to the {@link HttpConfiguration} used for the TLS-enabled connector being created.
+   * If the configuration is not set, it creates it using {@link #defaultHttpConfiguration()}.
+   * 
+   * @return the {@link HttpConfiguration} being used for the TLS-enabled connector.
+   */
+  public HttpConfiguration httpConfiguration() {
+
+    if (httpConfiguration == null) {
+      httpConfiguration = defaultHttpConfiguration();
+    }
+
+    return httpConfiguration;
+
+  }
+
+  /**
+   * Sets the port for the connector being created.
+   * 
+   * @param port the port for the connector
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withPort(int port) {
+
+    this.port = port;
+    return this;
+  }
+
+  /**
+   * Sets the certificate file for the connector being created.
+   * 
+   * @param certificateFile the certificate file
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withCertificateFile(String certificateFile) {
+
+    this.certificateFile = certificateFile;
+    return this;
+  }
+
+  /**
+   * Sets the certificate key file for the connector being created.
+   * 
+   * @param certificateKeyFile the certificate key file
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withCertificateKeyFile(String certificateKeyFile) {
+
+    this.certificateKeyFile = certificateKeyFile;
+    return this;
+  }
+
+  /**
+   * The the certificate key password for the connector being built
+   * 
+   * @param certificateKeyPassword the certificate key password
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withCertificateKeyPassword(char[] certificateKeyPassword) {
+
+    this.certicateKeyPassword = certificateKeyPassword;
+    return this;
+  }
+
+  /**
+   * Sets the if client authentication is required or not.
+   * 
+   * @param needClientAuth true if client authentication is required
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withNeedClientAuth(boolean needClientAuth) {
+
+    this.tlsNeedClientAuth = needClientAuth;
+    return this;
+  }
+
+  /**
+   * Sets if client authentication is wanted or not.
+   * 
+   * @param wantClientAuth true if client authentication is wanted
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withWantClientAuth(boolean wantClientAuth) {
+
+    this.tlsWantClientAuth = wantClientAuth;
+    return this;
+  }
+
+  /**
+   * Sets SSL included protocols. See {@link SslContextFactory#setIncludeProtocols(String...)}.
+   * 
+   * @param includeProtocols the array of included protocol names
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withIncludeProtocols(String... includeProtocols) {
+
+    this.includeProtocols = includeProtocols;
+    return this;
+  }
+
+  /**
+   * Sets SSL excluded protocols. See {@link SslContextFactory#setExcludeProtocols(String...)}.
+   * 
+   * @param excludeProtocols the array of excluded protocol names
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withExcludeProtocols(String... excludeProtocols) {
+
+    this.excludeProtocols = excludeProtocols;
+    return this;
+  }
+
+  /**
+   * Sets the SSL included cipher suites.
+   * 
+   * @param includeCipherSuites the array of included cipher suites.
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withIncludeCipherSuites(String... includeCipherSuites) {
+
+    this.includeCipherSuites = includeCipherSuites;
+    return this;
+  }
+
+  /**
+   * Sets the SSL ecluded cipher suites.
+   * 
+   * @param excludeCipherSuites the array of excluded cipher suites.
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withExcludeCipherSuites(String... excludeCipherSuites) {
+
+    this.excludeCipherSuites = excludeCipherSuites;
+    return this;
+  }
+
+  /**
+   * Sets the {@link HttpConfiguration} for the connector being built.
+   * 
+   * @param conf the {@link HttpConfiguration} to use
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withHttpConfiguration(HttpConfiguration conf) {
+
+    this.httpConfiguration = conf;
+    return this;
+  }
+
+  /**
+   * Sets the {@link KeyManager} for the connector being built.
+   * 
+   * @param km the {@link KeyManager} to use
+   * @return this builder
+   */
+  public TLSServerConnectorBuilder withKeyManager(KeyManager km) {
+
+    this.keyManager = km;
+    return this;
+  }
+
+  public TLSServerConnectorBuilder withConscrypt(boolean conscryptEnabled) {
+    this.useConscrypt = conscryptEnabled;
+    return this;
+  }
+
+  public TLSServerConnectorBuilder withHttp2(boolean http2Enabled) {
+    this.enableHttp2 = http2Enabled;
+    return this;
+  }
+
+  public TLSServerConnectorBuilder metricRegistry(MetricRegistry registry) {
+    this.registry = registry;
+    return this;
+  }
+
+  public TLSServerConnectorBuilder metricName(String metricName) {
+    this.metricName = metricName;
+    return this;
+  }
+
+  public TLSServerConnectorBuilder withTlsProtocol(String tlsProtocol) {
+    this.tlsProtocol = tlsProtocol;
+    return this;
+  }
+
+  public TLSServerConnectorBuilder withHostnameVerifier(HostnameVerifier verifier) {
+    this.hostnameVerifier = verifier;
+    return this;
+  }
+
+  public TLSServerConnectorBuilder withDisableJsseHostnameVerification(
+      boolean disableJsseHostnameVerification) {
+    this.disableJsseHostnameVerification = disableJsseHostnameVerification;
+    return this;
+  }
+
+  public TLSServerConnectorBuilder withAcceptors(int acceptors) {
+    this.acceptors = acceptors;
+    return this;
+  }
+
+  public TLSServerConnectorBuilder withSelectors(int selectors) {
+    this.selectors = selectors;
+    return this;
+  }
+
+  private SSLContext buildSSLContext() {
+
+    SSLContext sslCtx;
+
+    try {
+
+      KeyManager[] kms = new KeyManager[] {keyManager};
+      SSLTrustManager tm = new SSLTrustManager(certificateValidator);
+
+      if (useConscrypt) {
+
+        if (isNull(Security.getProvider(CONSCRYPT_PROVIDER))) {
+          Security.addProvider(new OpenSSLProvider());
+        }
+
+        sslCtx = SSLContext.getInstance(tlsProtocol, CONSCRYPT_PROVIDER);
+      } else {
+        sslCtx = SSLContext.getInstance(tlsProtocol);
+      }
+
+      sslCtx.init(kms, new TrustManager[] {tm}, null);
+
+    } catch (NoSuchAlgorithmException e) {
+
+      throw new TLSConnectorBuilderError("TLS protocol not supported: " + e.getMessage(), e);
+    } catch (KeyManagementException e) {
+      throw new TLSConnectorBuilderError(e);
+    } catch (NoSuchProviderException e) {
+      throw new TLSConnectorBuilderError("TLS provider error: " + e.getMessage(), e);
+    }
+
+    return sslCtx;
+  }
+
+  /**
+   * Builds a {@link ServerConnector} based on the {@link TLSServerConnectorBuilder} parameters
+   * 
+   * @return a {@link ServerConnector}
+   */
+  public ServerConnector build() {
+
+    if (keyManager == null) {
+      loadCredentials();
+    }
+
+    SSLContext sslContext = buildSSLContext();
+    SslContextFactory.Server cf = new SslContextFactory.Server();
+
+    cf.setSslContext(sslContext);
+
+
+    configureContextFactory(cf);
+
+    if (httpConfiguration == null) {
+      httpConfiguration = defaultHttpConfiguration();
+    }
+
+
+    HttpConnectionFactory httpConnFactory = new HttpConnectionFactory(httpConfiguration);
+    ConnectionFactory connFactory = null;
+
+    if (registry != null) {
+      connFactory = new InstrumentedConnectionFactory(httpConnFactory, registry.timer(metricName));
+    } else {
+      connFactory = httpConnFactory;
+    }
+
+
+    ConnectionFactory h2ConnFactory = null;
+    ServerConnector connector = null;
+
+    if (enableHttp2) {
+
+      HTTP2ServerConnectionFactory h2cf = new HTTP2ServerConnectionFactory(httpConfiguration);
+
+      if (registry != null) {
+        h2ConnFactory = new InstrumentedConnectionFactory(h2cf, registry.timer(metricName));
+      } else {
+        h2ConnFactory = h2cf;
+      }
+      ALPNServerConnectionFactory alpn = createAlpnProtocolFactory(httpConnFactory);
+      cf.setCipherComparator(HTTP2Cipher.COMPARATOR);
+      cf.setUseCipherSuitesOrder(true);
+
+      SslConnectionFactory sslCf = new SslConnectionFactory(cf, alpn.getProtocol());
+
+      connector = new ServerConnector(server, acceptors, selectors, sslCf, alpn, h2ConnFactory,
+          httpConnFactory);
+
+    } else {
+
+      connector = new ServerConnector(server, acceptors, selectors,
+          new SslConnectionFactory(cf, HttpVersion.HTTP_1_1.asString()), connFactory);
+    }
+
+    connector.setPort(port);
+    return connector;
+  }
+
+  private ALPNServerConnectionFactory createAlpnProtocolFactory(
+      HttpConnectionFactory httpConnectionFactory) {
+    ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
+    alpn.setDefaultProtocol(httpConnectionFactory.getProtocol());
+    return alpn;
+  }
+
+
+  /**
+   * Checks that file exists and is readable.
+   * 
+   * @param f the {@link File} to be checked
+   * @param prefix A prefix string for the error message, in case the file does not exist and is not
+   *        readable
+   * @throws RuntimeException if the file does not exist or is not readable
+   */
+  private void checkFileExistsAndIsReadable(File f, String prefix) {
+
+    String errorMessage = null;
+
+    if (!f.exists()) {
+      errorMessage = "File does not exists";
+    } else if (!f.canRead()) {
+      errorMessage = "File is not readable";
+    } else if (f.isDirectory()) {
+      errorMessage = "File is a directory";
+    }
+
+    if (errorMessage != null) {
+      String msg = String.format("%s: %s [%s]", prefix, errorMessage, f.getAbsolutePath());
+      throw new TLSConnectorBuilderError(msg);
+    }
+
+  }
+}

--- a/src/main/java/org/italiangrid/storm/webdav/server/util/ThreadPoolBuilder.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/util/ThreadPoolBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2012-2019.
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2014-2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/italiangrid/storm/webdav/server/util/ThreadPoolBuilder.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/util/ThreadPoolBuilder.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2012-2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.italiangrid.storm.webdav.server.util;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jetty9.InstrumentedQueuedThreadPool;
+
+/**
+ * 
+ * A builder to support thread pool configuration for a Jetty server.
+ *
+ */
+public class ThreadPoolBuilder {
+
+  /**
+   * 
+   */
+  public static final int DEFAULT_MAX_REQUEST_QUEUE_SIZE = 200;
+
+  public static final int DEFAULT_MAX_THREADS = 50;
+  public static final int DEFAULT_MIN_THREADS = 1;
+
+  public static final int DEFAULT_IDLE_TIMEOUT = (int) TimeUnit.MINUTES.toMillis(60);
+
+  public static final String DEFAULT_THREAD_POOL_METRIC_NAME = "thread-pool";
+  public static final String DEFAULT_THREAD_POOL_METRIC_PREFIX = "jetty";
+
+  private int maxThreads = DEFAULT_MAX_THREADS;
+  private int minThreads = DEFAULT_MIN_THREADS;
+
+  private int idleTimeout = DEFAULT_IDLE_TIMEOUT;
+  private int maxRequestQueueSize = DEFAULT_MAX_REQUEST_QUEUE_SIZE;
+
+  private String name = DEFAULT_THREAD_POOL_METRIC_NAME;
+  private String prefix = DEFAULT_THREAD_POOL_METRIC_PREFIX;
+
+  private MetricRegistry registry;
+
+  /**
+   * Returns a new {@link ThreadPoolBuilder} instance.
+   * 
+   * @return a {@link ThreadPoolBuilder}
+   */
+  public static ThreadPoolBuilder instance() {
+
+    return new ThreadPoolBuilder();
+  }
+
+  /**
+   * Sets the max number of threads for the thread pool.
+   * 
+   * @param maxNumberOfThreads the max number of threads
+   * 
+   * @return this builder
+   * 
+   */
+  public ThreadPoolBuilder withMaxThreads(int maxNumberOfThreads) {
+
+    this.maxThreads = maxNumberOfThreads;
+    return this;
+  }
+
+  /**
+   * Sets the minimum number of threads for the thread pool.
+   * 
+   * @param minNumberOfThreads the minimum number of threads
+   * @return this builder
+   */
+  public ThreadPoolBuilder withMinThreads(int minNumberOfThreads) {
+
+    this.minThreads = minNumberOfThreads;
+    return this;
+  }
+
+  /**
+   * Sets the maximum request queue size for this thread pool.
+   * 
+   * @param queueSize the maximum request queue size.
+   * 
+   * @return this builder
+   */
+  public ThreadPoolBuilder withMaxRequestQueueSize(int queueSize) {
+
+    this.maxRequestQueueSize = queueSize;
+    return this;
+  }
+
+  /**
+   * Sets the registry for this thread pool
+   * 
+   * @param registry the metric registry
+   * @return this builder
+   */
+  public ThreadPoolBuilder registry(MetricRegistry registry) {
+    this.registry = registry;
+    return this;
+  }
+
+  /**
+   * Sets the idle timeout in msec for this thread pool
+   * 
+   * @param idleTimeout the timeout in milliseconds
+   * @return this builder
+   */
+  public ThreadPoolBuilder withIdleTimeoutMsec(int idleTimeout) {
+    this.idleTimeout = idleTimeout;
+    return this;
+  }
+
+  /**
+   * Sets the name for this thread pool
+   *
+   * @param name the thread pool name
+   * @return this builder
+   */
+  public ThreadPoolBuilder withName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Sets the name prefix for this thread pool
+   *
+   * @param prefix the thread pool name prefix
+   * @return this builder
+   */
+  public ThreadPoolBuilder withPrefix(String prefix) {
+    this.prefix = prefix;
+    return this;
+  }
+
+
+  /**
+   * ctor.
+   * 
+   */
+  private ThreadPoolBuilder() {
+
+  }
+
+  /**
+   * Builds a {@link ThreadPool} based on the parameters of this builder
+   * 
+   * @return a {@link ThreadPool}
+   */
+  public ThreadPool build() {
+
+    if (maxRequestQueueSize <= 0) {
+      maxRequestQueueSize = DEFAULT_MAX_REQUEST_QUEUE_SIZE;
+    }
+
+    if (maxThreads <= 0) {
+      maxThreads = DEFAULT_MAX_THREADS;
+    }
+
+    if (minThreads <= 0) {
+      minThreads = DEFAULT_MIN_THREADS;
+    }
+
+    if (idleTimeout <= 0) {
+      idleTimeout = DEFAULT_IDLE_TIMEOUT;
+    }
+
+    if (prefix.isEmpty()) {
+      prefix = DEFAULT_THREAD_POOL_METRIC_PREFIX;
+    }
+
+    BlockingQueue<Runnable> queue = new ArrayBlockingQueue<Runnable>(maxRequestQueueSize);
+
+    QueuedThreadPool tp = null;
+
+    if (registry == null) {
+      tp = new QueuedThreadPool(maxThreads, minThreads, idleTimeout, queue);
+    } else {
+      tp = new InstrumentedQueuedThreadPool(registry, maxThreads, minThreads, idleTimeout, queue, prefix);
+    }
+
+    if (name.isEmpty()) {
+      name = DEFAULT_THREAD_POOL_METRIC_NAME;
+    }
+    tp.setName(name);
+
+    return tp;
+
+  }
+}

--- a/src/main/java/org/italiangrid/storm/webdav/spring/AppConfig.java
+++ b/src/main/java/org/italiangrid/storm/webdav/spring/AppConfig.java
@@ -307,10 +307,8 @@ public class AppConfig implements TransferConstants {
   ClientRegistrationRepository clientRegistrationRepository(
       OAuth2ClientProperties clientProperties, OAuthProperties props, ExecutorService executor) {
 
-
     ClientRegistrationCacheLoader loader =
         new ClientRegistrationCacheLoader(clientProperties, props, executor);
-
 
     LoadingCache<String, ClientRegistration> clients = CacheBuilder.newBuilder()
       .refreshAfterWrite(props.getRefreshPeriodMinutes(), TimeUnit.MINUTES)
@@ -345,7 +343,6 @@ public class AppConfig implements TransferConstants {
   @Bean
   JwtDecoder jwtDecoder(OAuthProperties props, ServiceConfigurationProperties sProps,
       RestTemplateBuilder builder, OidcConfigurationFetcher fetcher, ExecutorService executor) {
-
 
     TrustedJwtDecoderCacheLoader loader =
         new TrustedJwtDecoderCacheLoader(sProps, props, builder, fetcher, executor);

--- a/src/main/java/org/italiangrid/storm/webdav/spring/AppConfig.java
+++ b/src/main/java/org/italiangrid/storm/webdav/spring/AppConfig.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.spring;
 
 import static java.util.Objects.isNull;
-import static org.italiangrid.utils.jetty.TLSServerConnectorBuilder.CONSCRYPT_PROVIDER;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -129,6 +128,7 @@ import eu.emi.security.authn.x509.impl.PEMCredential;
 public class AppConfig implements TransferConstants {
 
   public static final Logger LOG = LoggerFactory.getLogger(AppConfig.class);
+  public static final String CONSCRYPT_PROVIDER = "Conscrypt";
 
   @Bean
   Clock systemClock() {

--- a/src/main/java/org/italiangrid/storm/webdav/tpc/utils/ClientInfo.java
+++ b/src/main/java/org/italiangrid/storm/webdav/tpc/utils/ClientInfo.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.util.Map;
 
-import org.apache.log4j.MDC;
+import org.slf4j.MDC;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Splitter.MapSplitter;

--- a/src/main/java/org/italiangrid/storm/webdav/tpc/utils/ClientInfo.java
+++ b/src/main/java/org/italiangrid/storm/webdav/tpc/utils/ClientInfo.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.util.Map;
 
-import org.slf4j.MDC;
+import org.apache.log4j.MDC;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Splitter.MapSplitter;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,7 +50,8 @@ tpc:
   enable-expect-continue-threshold: ${STORM_WEBDAV_TPC_ENABLE_EXPECT_CONTINUE_THRESHOLD:1048576}
 
 oauth:
-  refresh-period-minutes: 60
+  refresh-period-minutes: ${STORM_WEBDAV_OAUTH_REFRESH_PERIOD_MINUTES:60}
+  refresh-timeout-seconds: ${STORM_WEBDAV_OAUTH_REFRESH_TIMEOUT_SECONDS:30}
   issuers:
 
 storm:

--- a/src/test/java/org/italiangrid/storm/webdav/test/oauth/jwk/OidcConfigurationFetcherTests.java
+++ b/src/test/java/org/italiangrid/storm/webdav/test/oauth/jwk/OidcConfigurationFetcherTests.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2014-2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.italiangrid.storm.webdav.test.oauth.jwk;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.text.ParseException;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.italiangrid.storm.webdav.config.OAuthProperties;
+import org.italiangrid.storm.webdav.oauth.utils.DefaultOidcConfigurationFetcher;
+import org.italiangrid.storm.webdav.oauth.utils.OidcConfigurationFetcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import com.google.common.collect.Maps;
+import com.nimbusds.jose.RemoteKeySourceException;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyType;
+
+@ExtendWith(MockitoExtension.class)
+public class OidcConfigurationFetcherTests {
+
+  final static String ISSUER = "https://iam-dev.cloud.cnaf.infn.it/";
+  final static String JWK_URI = "https://iam-dev.cloud.cnaf.infn.it/jwk";
+
+  final static String KID = "rsa1";
+  
+
+  final ParameterizedTypeReference<Map<String, Object>> typeReference =
+      new ParameterizedTypeReference<Map<String, Object>>() {};
+
+  @Mock
+  RestTemplate restTemplate;
+  @Mock
+  RestTemplateBuilder restBuilder;
+  @Mock
+  OAuthProperties oAuthProperties;
+
+  @SuppressWarnings("unchecked")
+  private ResponseEntity<Map<String, Object>> getMockedResponseFromWellKnown() {
+
+    Map<String, Object> wellKnownMap = Maps.newHashMap();
+    wellKnownMap.put("issuer", ISSUER);
+    wellKnownMap.put("jwks_uri", JWK_URI);
+    ResponseEntity<Map<String, Object>> mockedEntity = (ResponseEntity<Map<String, Object>>) Mockito.mock(ResponseEntity.class);
+    lenient().when(mockedEntity.getBody()).thenReturn(wellKnownMap);
+    return mockedEntity;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ResponseEntity<String> getMockedResponseFromJWKURI() throws IOException {
+
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("jwk/test-keystore.jwks").getFile());
+    String data = FileUtils.readFileToString(file, "UTF-8");
+    ResponseEntity<String> mockedEntity = (ResponseEntity<String>) Mockito.mock(ResponseEntity.class);
+    lenient().when(mockedEntity.getBody()).thenReturn(data);
+    lenient().when(mockedEntity.getStatusCodeValue()).thenReturn(200);
+    return mockedEntity;
+  }
+  
+  private OidcConfigurationFetcher getFetcher() throws RestClientException, IOException {
+
+    ResponseEntity<Map<String, Object>> mockedResponseMapEntity = getMockedResponseFromWellKnown();
+    lenient().when(restTemplate.exchange(any(), eq(typeReference))).thenReturn(mockedResponseMapEntity);
+    ResponseEntity<String> mockedResponseStringEntity = getMockedResponseFromJWKURI();
+    lenient().when(restTemplate.exchange(any(), eq(String.class))).thenReturn(mockedResponseStringEntity);
+
+    lenient().when(restBuilder.build()).thenReturn(restTemplate);
+    lenient().when(restBuilder.setConnectTimeout(any())).thenReturn(restBuilder);
+    lenient().when(restBuilder.setReadTimeout(any())).thenReturn(restBuilder);
+    lenient().when(oAuthProperties.getRefreshTimeoutSeconds()).thenReturn(30);
+    lenient().when(oAuthProperties.getRefreshPeriodMinutes()).thenReturn(1);
+
+    return new DefaultOidcConfigurationFetcher(restBuilder, oAuthProperties);
+  }
+
+  @Test
+  public void fetchWellKnownEndpointTests() throws RestClientException, IOException {
+
+    OidcConfigurationFetcher fetcher = getFetcher();
+    Map<String, Object> conf = fetcher.loadConfigurationForIssuer(ISSUER);
+    assertNotNull(conf);
+    assertThat(conf.get("issuer"), is(ISSUER));
+    assertThat(conf.get("jwks_uri"), is(JWK_URI));
+  }
+
+  @Test
+  public void fetchJWKEndpointTests() throws RestClientException, IOException, RemoteKeySourceException, ParseException {
+
+    OidcConfigurationFetcher fetcher = getFetcher();
+    JWKSet key = JWKSet.parse(fetcher.loadJWKSourceForURL(URI.create(JWK_URI)));
+
+    assertNotNull(key.getKeyByKeyId(KID));
+    assertThat(key.getKeyByKeyId(KID).getKeyType(), is(KeyType.RSA));
+  }
+}

--- a/src/test/java/org/italiangrid/storm/webdav/test/oauth/jwk/TrustedJwtDecoderCacheLoaderTests.java
+++ b/src/test/java/org/italiangrid/storm/webdav/test/oauth/jwk/TrustedJwtDecoderCacheLoaderTests.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2014-2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.italiangrid.storm.webdav.test.oauth.jwk;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.commons.io.FileUtils;
+import org.italiangrid.storm.webdav.config.OAuthProperties;
+import org.italiangrid.storm.webdav.config.ServiceConfigurationProperties;
+import org.italiangrid.storm.webdav.config.ServiceConfigurationProperties.AuthorizationServerProperties;
+import org.italiangrid.storm.webdav.config.OAuthProperties.AuthorizationServer;
+import org.italiangrid.storm.webdav.oauth.utils.OidcConfigurationFetcher;
+import org.italiangrid.storm.webdav.oauth.utils.TrustedJwtDecoderCacheLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.nimbusds.jose.RemoteKeySourceException;
+
+@ExtendWith(MockitoExtension.class)
+public class TrustedJwtDecoderCacheLoaderTests {
+
+  private final String ISSUER = "https://wlcg.cloud.cnaf.infn.it/";
+  private final String JWK_URI = "https://wlcg.cloud.cnaf.infn.it/jwks";
+
+  @Mock
+  ServiceConfigurationProperties properties;
+  @Mock
+  OAuthProperties oauthProperties;
+  @Mock
+  RestTemplateBuilder builder;
+  @Mock
+  OidcConfigurationFetcher fetcher;
+
+  private ExecutorService executor;
+  private TrustedJwtDecoderCacheLoader jwtLoader;
+
+  @BeforeEach
+  public void setup() throws IOException, RemoteKeySourceException {
+
+    AuthorizationServer as = new AuthorizationServer();
+    as.setIssuer(ISSUER);
+    as.setJwkUri(JWK_URI);
+    List<AuthorizationServer> issuerServers = Lists.newArrayList(as);
+    lenient().when(oauthProperties.getIssuers()).thenReturn(issuerServers);
+
+    Map<String, Object> oidcConfiguration = Maps.newHashMap();
+    oidcConfiguration.put("issuer", ISSUER);
+    oidcConfiguration.put("jwks_uri", JWK_URI);
+
+    ClassLoader classLoader = getClass().getClassLoader();
+    File file = new File(classLoader.getResource("jwk/test-keystore.jwks").getFile());
+    String data = FileUtils.readFileToString(file, "UTF-8");
+
+    lenient().when(fetcher.loadConfigurationForIssuer(ISSUER)).thenReturn(oidcConfiguration);
+    lenient().when(fetcher.loadJWKSourceForURL(URI.create(JWK_URI))).thenReturn(data);
+
+    AuthorizationServerProperties props = new AuthorizationServerProperties();
+    props.setEnabled(false);
+    props.setIssuer("http://localhost");
+    lenient().when(properties.getAuthzServer()).thenReturn(props);
+
+    executor = Executors.newScheduledThreadPool(1);
+
+    jwtLoader =
+        new TrustedJwtDecoderCacheLoader(properties, oauthProperties, builder, fetcher, executor);
+
+  }
+
+  @Test
+  public void testLoadRemoteIssuerConfiguration() throws Exception {
+
+    JwtDecoder decoder = jwtLoader.load(ISSUER);
+    assertTrue(decoder instanceof NimbusJwtDecoder);
+    ListenableFuture<JwtDecoder> reloaded = jwtLoader.reload(ISSUER, decoder);
+    JwtDecoder newDecoder = reloaded.get();
+    assertTrue(newDecoder instanceof NimbusJwtDecoder);
+  }
+}

--- a/src/test/java/org/italiangrid/storm/webdav/test/oauth/jwt/NoExpirationStringCacheTests.java
+++ b/src/test/java/org/italiangrid/storm/webdav/test/oauth/jwt/NoExpirationStringCacheTests.java
@@ -1,0 +1,30 @@
+package org.italiangrid.storm.webdav.test.oauth.jwt;
+
+import static org.junit.Assert.assertEquals;
+
+import org.italiangrid.storm.webdav.oauth.utils.NoExpirationStringCache;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class NoExpirationStringCacheTests {
+
+  final String CACHED_VALUE = "this-is-my-cached-value";
+  final String FAKE_ISSUER = "http://localhost";
+
+  @Test
+  public void noExpirationCacheWorks() {
+
+    NoExpirationStringCache cache = new NoExpirationStringCache(CACHED_VALUE);
+
+    assertEquals("NoExpirationCache", cache.getName());
+    assertEquals(cache, cache.getNativeCache());
+    assertEquals(CACHED_VALUE, cache.get(FAKE_ISSUER).get());
+    cache.clear();
+    cache.put(FAKE_ISSUER, CACHED_VALUE);
+    assertEquals(CACHED_VALUE, cache.get(FAKE_ISSUER).get());
+    cache.evict(FAKE_ISSUER);
+    assertEquals(CACHED_VALUE, cache.get(FAKE_ISSUER).get());
+  }
+}

--- a/src/test/java/org/italiangrid/storm/webdav/test/utils/TLSConnectorBuilderTests.java
+++ b/src/test/java/org/italiangrid/storm/webdav/test/utils/TLSConnectorBuilderTests.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2014-2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.italiangrid.storm.webdav.test.utils;
+
+import static org.junit.Assert.assertThrows;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.KeyManager;
+
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.italiangrid.storm.webdav.server.util.CANLListener;
+import org.italiangrid.storm.webdav.server.util.TLSConnectorBuilderError;
+import org.italiangrid.storm.webdav.server.util.TLSServerConnectorBuilder;
+import org.italiangrid.voms.util.CertificateValidatorBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import eu.emi.security.authn.x509.CrlCheckingMode;
+import eu.emi.security.authn.x509.NamespaceCheckingMode;
+import eu.emi.security.authn.x509.OCSPCheckingMode;
+import eu.emi.security.authn.x509.X509CertChainValidatorExt;
+
+@ExtendWith(MockitoExtension.class)
+public class TLSConnectorBuilderTests {
+
+  @Test
+  public void tlsConnectorBuilderErrorTests() {
+
+    new TLSConnectorBuilderError("This is an error!");
+    new TLSConnectorBuilderError("This is an error!", new RuntimeException());
+    new TLSConnectorBuilderError(new RuntimeException());
+  }
+
+  @Test
+  public void illegalArgumentExceptionThrown() {
+
+    Server server = Mockito.mock(Server.class);
+    X509CertChainValidatorExt validator = Mockito.mock(X509CertChainValidatorExt.class);
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      TLSServerConnectorBuilder.instance(null, validator);
+    });
+    assertThrows(IllegalArgumentException.class, () -> {
+      TLSServerConnectorBuilder.instance(server, null);
+    });
+    assertThrows(IllegalArgumentException.class, () -> {
+      TLSServerConnectorBuilder.instance(null, null);
+    });
+  }
+
+  private X509CertChainValidatorExt getValidator() {
+
+    CANLListener l = new org.italiangrid.storm.webdav.server.util.CANLListener();
+    CertificateValidatorBuilder builder = new CertificateValidatorBuilder();
+
+    long refreshInterval = TimeUnit.SECONDS.toMillis(3600);
+
+    return builder.namespaceChecks(NamespaceCheckingMode.EUGRIDPMA_AND_GLOBUS_REQUIRE)
+      .crlChecks(CrlCheckingMode.IF_VALID)
+      .ocspChecks(OCSPCheckingMode.IGNORE)
+      .lazyAnchorsLoading(false)
+      .storeUpdateListener(l)
+      .validationErrorListener(l)
+      .trustAnchorsDir("src/test/resources/trust-anchors")
+      .trustAnchorsUpdateInterval(refreshInterval)
+      .build();
+  }
+
+  @Test
+  public void tlsConnectorBuilderTests() {
+
+    Server server = new Server();
+    X509CertChainValidatorExt validator = getValidator();
+    TLSServerConnectorBuilder builder = TLSServerConnectorBuilder.instance(server, validator);
+    HttpConfiguration httpConfiguration = builder.httpConfiguration();
+    KeyManager keyManager = Mockito.mock(KeyManager.class);
+    builder.withPort(1234)
+      .withCertificateFile("fake-certificate")
+      .withCertificateKeyFile("fake-key")
+      .withHttpConfiguration(httpConfiguration)
+      .withKeyManager(keyManager)
+      .withExcludeCipherSuites("one", "two")
+      .withIncludeProtocols("protocol", "another-protocol");
+
+    builder.build();
+  }
+}

--- a/src/test/java/org/italiangrid/storm/webdav/test/utils/ThreadPoolBuilderTests.java
+++ b/src/test/java/org/italiangrid/storm/webdav/test/utils/ThreadPoolBuilderTests.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2014-2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.italiangrid.storm.webdav.test.utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.italiangrid.storm.webdav.server.util.ThreadPoolBuilder.DEFAULT_IDLE_TIMEOUT;
+import static org.italiangrid.storm.webdav.server.util.ThreadPoolBuilder.DEFAULT_MAX_THREADS;
+import static org.italiangrid.storm.webdav.server.util.ThreadPoolBuilder.DEFAULT_MIN_THREADS;
+import static org.italiangrid.storm.webdav.server.util.ThreadPoolBuilder.DEFAULT_THREAD_POOL_METRIC_NAME;
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
+import org.italiangrid.storm.webdav.server.util.ThreadPoolBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jetty9.InstrumentedQueuedThreadPool;
+
+@ExtendWith(MockitoExtension.class)
+public class ThreadPoolBuilderTests {
+
+  final static String PREFIX = "iam";
+  final static String NAME = "queue";
+  final static int IDLE_TIMEOUT = 6;
+  final static int MIN_THREADS = 10;
+  final static int MAX_THREADS = 20;
+  final static int MAX_QUEUE_SIZE = 40;
+
+  @Mock
+  MetricRegistry registry;
+
+  @Test
+  public void threadPoolBuilderTests() {
+
+    ThreadPool tp = ThreadPoolBuilder.instance()
+      .withMinThreads(MIN_THREADS)
+      .withMaxThreads(MAX_THREADS)
+      .withIdleTimeoutMsec(IDLE_TIMEOUT)
+      .withMaxRequestQueueSize(MAX_QUEUE_SIZE)
+      .withName(NAME)
+      .withPrefix(PREFIX)
+      .build();
+    assertNotNull(tp);
+    assertThat(tp.getClass(), is(QueuedThreadPool.class));
+    QueuedThreadPool qtp = (QueuedThreadPool) tp;
+    assertThat(qtp.getMinThreads(), is(MIN_THREADS));
+    assertThat(qtp.getMaxThreads(), is(MAX_THREADS));
+    assertThat(qtp.getIdleTimeout(), is(IDLE_TIMEOUT));
+    assertThat(qtp.getMaxAvailableThreads(), is(MAX_THREADS));
+    assertThat(qtp.getName(), is(NAME));
+  }
+
+  @Test
+  public void threadPoolBuilderWithDefaultValuesTests() {
+
+    ThreadPool tp = ThreadPoolBuilder.instance().build();
+    assertNotNull(tp);
+    assertThat(tp.getClass(), is(QueuedThreadPool.class));
+    QueuedThreadPool qtp = (QueuedThreadPool) tp;
+    assertThat(qtp.getMinThreads(), is(DEFAULT_MIN_THREADS));
+    assertThat(qtp.getMaxThreads(), is(DEFAULT_MAX_THREADS));
+    assertThat(qtp.getIdleTimeout(), is(DEFAULT_IDLE_TIMEOUT));
+    assertThat(qtp.getMaxAvailableThreads(), is(DEFAULT_MAX_THREADS));
+    assertThat(qtp.getName(), is(DEFAULT_THREAD_POOL_METRIC_NAME));
+  }
+
+  @Test
+  public void threadPoolBuilderWithRegistryTests() {
+
+    ThreadPool tp = ThreadPoolBuilder.instance().registry(registry).build();
+    assertNotNull(tp);
+    assertThat(tp.getClass(), is(InstrumentedQueuedThreadPool.class));
+    InstrumentedQueuedThreadPool qtp = (InstrumentedQueuedThreadPool) tp;
+    assertThat(qtp.getMinThreads(), is(DEFAULT_MIN_THREADS));
+    assertThat(qtp.getMaxThreads(), is(DEFAULT_MAX_THREADS));
+    assertThat(qtp.getIdleTimeout(), is(DEFAULT_IDLE_TIMEOUT));
+    assertThat(qtp.getMaxAvailableThreads(), is(DEFAULT_MAX_THREADS));
+    assertThat(qtp.getName(), is(DEFAULT_THREAD_POOL_METRIC_NAME));
+  }
+}

--- a/src/test/resources/jwk/test-keystore.jwks
+++ b/src/test/resources/jwk/test-keystore.jwks
@@ -1,0 +1,16 @@
+{
+  "keys": [
+    {
+      "p": "-qdvzeHU7w_ToV2RlS2QlVggXNL2YfpRWQxvrO8pHZC_dVgYFwKz5nadOMzR1BK0tPuCTWuuI66sFgaA9VENGypdIYoCF2O1FBLFK6GjOO-uc0LZEbIDa6Xn0G7UYOWcLaiYriHTtC_Pzp11L7VGjrUlX4HRgU_B3X1oeGn0mbM",
+      "kty": "RSA",
+      "q": "5S2b9tYHi9zBcNGZ8X6GM4TAL4UU9mABH0rKIyzbudkG7Wxxbj6I18skuHzfOOPI4c8sTQSv6IVAr2n1bn3_E5RSyPpbtDSCTYGzhijXl9wZ0ba2NidFrVjnL-KPx_gcHKnUHebKvsIEdjxeuqaaZ1kqEJX326b450Frghd78p8",
+      "d": "oDb1qfQTaP73jEZHgkOG5C9dY5EJZW57fX_BYUJ-yYTuTHPWZBVDKw9I_Ir1tSYyuTF-Bfb4iPim46gnEBM3AdvMian2iajvrN_rJFUJHo65vtY9xCXCD0d_Jct5JMyOafP5LF3cP38yDcyZRS_JeyKGB6U1KhbL-gG4hrQGS8qO3rdY_JQiLDLVdRRptHsPphS44JHXdP2qeVNJ41-CTfPWKiMIUOC0fj-As-dbTzRXuLXs04NayAdM-yhvRiwKujEfL8YbKW9CDJIgJfm2vzWHXFus5Y11S2Zr65cWxxVvRfnAFbFO1AkIkJc2jHZ4xLxfDU2kTi20sOMq1UFrvQ",
+      "e": "AQAB",
+      "kid": "rsa1",
+      "qi": "bN1wnq_0VkJlECMGPmeRFdZCX2LgAMrgwbJpysRw5J04vO9YsVmAcB_4xqoDjDUg7koioAp3IOhMGjOJWpYzCqWzsaA_84kX4WKGsr2xz6oaFSgt1FvtBY4GqEeZj8RG0LMtEtKSyjHGieA0hd4TUcqSdNZ4osT98Bfd7z3peYc",
+      "dp": "YfyaxI2IRHyXavm9M-hAIWH2JNOD5gGJU5p8_cnw9NHlRuZNZJF16p5sEAxh6tn1MtsvsTxrMx_RvjqEp2IsEXaaOcZN0v7zhwlfcxMZT-TC-eQkH7rLg4Wz_dOVytt4FpFWPpySuloGjusXKLNhBeDi31dMo5SeYQvpj0k8iek",
+      "dq": "9_lhyLPNdohmxqwE5kkA7L23NbPJ-svmavWBwo3HMlCiLkQoeCEx8EzebsCux9-wfKSuSqfHrtCALU15QxUR6x2SdeRvVY17cGHm3kNTA_4j8cbBYdccjXSksitzZ-wOfvVDjxcqST2llkm8NjoO18Siv0-F4SXKLG-c5CaE9w",
+      "n": "4GRvJuFantVV3JdjwQOAkfREnwUFp2znRBTOIJhPamyH4gf4YlI5PQT79415NV4_HrWYzgooH5AK6-7WE-TLLGEAVK5vdk4vv79bG7ukvjvBPxAjEhQn6-Amln88iXtvicEGbh--3CKbQj1jryVU5aWM6jzweaabFSeCILVEd6ZT7ofXaAqan9eLzU5IEtTPy5MfrrOvWw5Q7D2yzMqc5LksmaQSw8XtmhA8gnENnIqjAMmPtRltf93wjtmiamgVENOVPdN-93Nd5w-pnMwEyoO6Q9JqXxV6lD6qBRxI7_5t4_vmVxcbbxcZbSAMoHqA2pbSMJ4Jcw-27Hct9jesLQ"
+    }
+  ]
+}


### PR DESCRIPTION
Other fixes:
- move spring-boot version from 2.7.17 to 2.7.18
- added classes and dependencies necessary to remove jetty-utils
- voms-api-java now is a direct dependency

Fix: https://issues.infn.it/jira/browse/STOR-1603