### PR TITLE
Update WLCG policy decision point logic

### DIFF
--- a/src/main/java/org/italiangrid/storm/webdav/authz/pdp/WlcgStructuredPathAuthorizationPdp.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/pdp/WlcgStructuredPathAuthorizationPdp.java
@@ -58,9 +58,9 @@ public class WlcgStructuredPathAuthorizationPdp
   public static final String STORAGE_READ = "storage.read";
   public static final String STORAGE_MODIFY = "storage.modify";
   public static final String STORAGE_CREATE = "storage.create";
-  public static final Set<String> ALL_STORAGE_SCOPES =
-      Sets.newHashSet(STORAGE_READ, STORAGE_MODIFY, STORAGE_CREATE, STORAGE_STAGE);
 
+  protected static final Set<String> ALL_STORAGE_SCOPES =
+      Sets.newHashSet(STORAGE_READ, STORAGE_MODIFY, STORAGE_CREATE, STORAGE_STAGE);
 
   public static final String ERROR_INVALID_AUTHENTICATION =
       "Invalid authentication: expected a JwtAuthenticationToken object";
@@ -72,13 +72,10 @@ public class WlcgStructuredPathAuthorizationPdp
 
   public static final String ERROR_UNKNOWN_TOKEN_ISSUER = "Unknown token issuer: %s";
 
-  public static final Set<String> READONLY_METHODS = Sets.newHashSet("GET", "PROPFIND");
-
-  public static final Set<String> REPLACE_METHODS = Sets.newHashSet("PUT", "MKCOL");
-
-  public static final Set<String> MODIFY_METHODS = Sets.newHashSet("PATCH", "DELETE");
-
-  public static final Set<String> CATCHALL_METHODS = Sets.newHashSet("HEAD", "OPTIONS");
+  protected static final Set<String> READONLY_METHODS = Sets.newHashSet("GET", "PROPFIND");
+  protected static final Set<String> REPLACE_METHODS = Sets.newHashSet("PUT", "MKCOL");
+  protected static final Set<String> MODIFY_METHODS = Sets.newHashSet("PATCH", "DELETE");
+  protected static final Set<String> CATCHALL_METHODS = Sets.newHashSet("HEAD", "OPTIONS");
 
   public static final String COPY_METHOD = "COPY";
   public static final String MOVE_METHOD = "MOVE";

--- a/src/main/java/org/italiangrid/storm/webdav/authz/pdp/WlcgStructuredPathAuthorizationPdp.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/pdp/WlcgStructuredPathAuthorizationPdp.java
@@ -47,16 +47,20 @@ public class WlcgStructuredPathAuthorizationPdp
     implements PathAuthorizationPdp, MatcherUtils, TpcUtils {
 
   public static final String WLCG_STORAGE_SCOPE_PATTERN_STRING =
-      "^storage.(read|modify|create):(\\/.*)$";
+      "^storage.(read|modify|create|stage):(\\/.*)$";
 
   public static final Pattern WLCG_STORAGE_SCOPE_PATTERN =
       Pattern.compile(WLCG_STORAGE_SCOPE_PATTERN_STRING);
 
   public static final String SCOPE_CLAIM = "scope";
 
+  public static final String STORAGE_STAGE = "storage.stage";
   public static final String STORAGE_READ = "storage.read";
   public static final String STORAGE_MODIFY = "storage.modify";
   public static final String STORAGE_CREATE = "storage.create";
+  public static final Set<String> ALL_STORAGE_SCOPES =
+      Sets.newHashSet(STORAGE_READ, STORAGE_MODIFY, STORAGE_CREATE, STORAGE_STAGE);
+
 
   public static final String ERROR_INVALID_AUTHENTICATION =
       "Invalid authentication: expected a JwtAuthenticationToken object";
@@ -68,12 +72,13 @@ public class WlcgStructuredPathAuthorizationPdp
 
   public static final String ERROR_UNKNOWN_TOKEN_ISSUER = "Unknown token issuer: %s";
 
-  public static final Set<String> READONLY_METHODS =
-      Sets.newHashSet("GET", "OPTIONS", "HEAD", "PROPFIND");
+  public static final Set<String> READONLY_METHODS = Sets.newHashSet("GET", "PROPFIND");
 
   public static final Set<String> REPLACE_METHODS = Sets.newHashSet("PUT", "MKCOL");
 
   public static final Set<String> MODIFY_METHODS = Sets.newHashSet("PATCH", "DELETE");
+
+  public static final Set<String> CATCHALL_METHODS = Sets.newHashSet("HEAD", "OPTIONS");
 
   public static final String COPY_METHOD = "COPY";
   public static final String MOVE_METHOD = "MOVE";
@@ -125,39 +130,39 @@ public class WlcgStructuredPathAuthorizationPdp
   boolean filterMatcherByRequest(HttpServletRequest request, String method,
       StructuredPathScopeMatcher m, boolean requestedResourceExists) {
 
-    String requiredScope = null;
+    if (CATCHALL_METHODS.contains(method)) {
+      return ALL_STORAGE_SCOPES.stream().anyMatch(prefix -> m.getPrefix().equals(prefix));
+    }
 
     if (READONLY_METHODS.contains(method)) {
-      requiredScope = STORAGE_READ;
-    } else if (REPLACE_METHODS.contains(method)) {
+      return m.getPrefix().equals(STORAGE_READ) || m.getPrefix().equals(STORAGE_STAGE);
+    }
+    if (REPLACE_METHODS.contains(method)) {
       if (requestedResourceExists) {
-        requiredScope = STORAGE_MODIFY;
-      } else {
-        requiredScope = STORAGE_CREATE;
+        return m.getPrefix().equals(STORAGE_MODIFY);
       }
-    } else if (MODIFY_METHODS.contains(method)) {
-      requiredScope = STORAGE_MODIFY;
-    } else if (COPY_METHOD.equals(method)) {
-
-      requiredScope = STORAGE_READ;
+      return m.getPrefix().equals(STORAGE_CREATE);
+    }
+    if (MODIFY_METHODS.contains(method)) {
+      return m.getPrefix().equals(STORAGE_MODIFY);
+    }
+    if (COPY_METHOD.equals(method)) {
 
       if (isPullTpc(request, localUrlService)) {
         if (requestedResourceExists) {
-          requiredScope = STORAGE_MODIFY;
-        } else {
-          requiredScope = STORAGE_CREATE;
+          return m.getPrefix().equals(STORAGE_MODIFY);
         }
+        return m.getPrefix().equals(STORAGE_CREATE);
       }
+      return m.getPrefix().equals(STORAGE_READ);
 
-    } else if (MOVE_METHOD.equals(method)) {
-      requiredScope = STORAGE_MODIFY;
     }
 
-    if (isNull(requiredScope)) {
-      throw new IllegalArgumentException(format(ERROR_UNSUPPORTED_METHOD_PATTERN, method));
+    if (MOVE_METHOD.equals(method)) {
+      return m.getPrefix().equals(STORAGE_MODIFY);
     }
 
-    return m.getPrefix().equals(requiredScope);
+    throw new IllegalArgumentException(format(ERROR_UNSUPPORTED_METHOD_PATTERN, method));
   }
 
 
@@ -186,7 +191,7 @@ public class WlcgStructuredPathAuthorizationPdp
     if (isNull(sa)) {
       return indeterminate(ERROR_SA_NOT_FOUND);
     }
-    
+
     final String tokenIssuer = jwtAuth.getToken().getIssuer().toString();
 
     if (!sa.orgs().contains(tokenIssuer)) {

--- a/src/test/java/org/italiangrid/storm/webdav/test/authz/pdp/ScopePathAuthzPdpTests.java
+++ b/src/test/java/org/italiangrid/storm/webdav/test/authz/pdp/ScopePathAuthzPdpTests.java
@@ -101,7 +101,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void invalidAuthentication() {
+  void invalidAuthentication() {
 
     Authentication auth = mock(Authentication.class);
     assertThrows(IllegalArgumentException.class, () -> {
@@ -110,7 +110,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void noScopeClaimYeldsIndeterminate() throws Exception {
+  void noScopeClaimYeldsIndeterminate() throws Exception {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn(null);
     PathAuthorizationResult result =
         pdp.authorizeRequest(newAuthorizationRequest(request, jwtAuth));
@@ -120,7 +120,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void noSaYeldsIndeterminate() throws Exception {
+  void noSaYeldsIndeterminate() throws Exception {
 
     when(pathResolver.resolveStorageArea("/test/example")).thenReturn(null);
     PathAuthorizationResult result =
@@ -131,7 +131,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void noStorageScopesYeldsDeny() throws Exception {
+  void noStorageScopesYeldsDeny() throws Exception {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid profile storage.read");
 
     PathAuthorizationResult result =
@@ -143,7 +143,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void noStorageScopesYeldsDenyForCatchallMethods() throws Exception {
+  void noStorageScopesYeldsDenyForCatchallMethods() {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid profile");
 
     for (String m : CATCHALL_METHODS) {
@@ -158,7 +158,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void catchallMethodsRequestsAtLeastOneStorageScope() throws Exception {
+  void catchallMethodsRequestsAtLeastOneStorageScope() {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.modify:/");
 
     for (String m : CATCHALL_METHODS) {
@@ -197,7 +197,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void readMethodsRequestsRequireStorageReadOrStage() throws Exception {
+  void readMethodsRequestsRequireStorageReadOrStage() {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.modify:/");
 
     for (String m : READ_METHODS) {
@@ -229,7 +229,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void replaceMethodsRequestsRequireStorageModifyOrCreate() throws Exception {
+  void replaceMethodsRequestsRequireStorageModifyOrCreate() throws Exception {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/");
 
     for (String m : REPLACE_METHODS) {
@@ -273,7 +273,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void modifyMethodsRequestsRequireStorageModifyOrCreate() throws Exception {
+  void modifyMethodsRequestsRequireStorageModifyOrCreate() throws Exception {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/ storage.create:/");
 
     for (String m : MODIFY_METHODS) {
@@ -296,7 +296,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void testLocalCopyRequiresStorageCreateOrModify() throws Exception {
+  void testLocalCopyRequiresStorageCreateOrModify() throws Exception {
 
     when(request.getMethod()).thenReturn(COPY_METHOD);
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.modify:/");
@@ -313,7 +313,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void testPullTpcRequiresCreateOrModify() throws Exception {
+  void testPullTpcRequiresCreateOrModify() throws Exception {
     when(request.getMethod()).thenReturn(COPY_METHOD);
     when(request.getHeader("Source")).thenReturn("https://remote.example/test/example");
     when(pathResolver.pathExists("/test/example")).thenReturn(true);
@@ -341,7 +341,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void testPushTpcRequiresRead() throws Exception {
+  void testPushTpcRequiresRead() throws Exception {
     when(request.getMethod()).thenReturn(COPY_METHOD);
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.create:/ storage.modify:/");
     PathAuthorizationResult result =
@@ -357,7 +357,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void testMoveRequiresModify() throws Exception {
+  void testMoveRequiresModify() throws Exception {
     when(request.getMethod()).thenReturn(MOVE_METHOD);
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/ storage.create:/");
     PathAuthorizationResult result =
@@ -373,7 +373,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void testModifyImpliesCreate() throws Exception {
+  void testModifyImpliesCreate() throws Exception {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/ storage.modify:/");
     when(pathResolver.pathExists("/test/example")).thenReturn(false);
 
@@ -386,7 +386,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void testUnsupportedMethod() throws Exception {
+  void testUnsupportedMethod() throws Exception {
     when(request.getMethod()).thenReturn("TRACE");
     assertThrows(IllegalArgumentException.class, () -> {
       pdp.authorizeRequest(newAuthorizationRequest(request, jwtAuth));
@@ -394,7 +394,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void testPathAuthzIsEnforced() throws Exception {
+  void testPathAuthzIsEnforced() throws Exception {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/subfolder");
     when(request.getMethod()).thenReturn("GET");
     PathAuthorizationResult result =
@@ -410,7 +410,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  public void issuerChecksAreEnforced() throws Exception {
+  void issuerChecksAreEnforced() throws Exception {
     when(jwt.getIssuer()).thenReturn(new URL("https://unknown.example"));
     when(request.getMethod()).thenReturn("GET");
     PathAuthorizationResult result =

--- a/src/test/java/org/italiangrid/storm/webdav/test/authz/pdp/ScopePathAuthzPdpTests.java
+++ b/src/test/java/org/italiangrid/storm/webdav/test/authz/pdp/ScopePathAuthzPdpTests.java
@@ -110,7 +110,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void noScopeClaimYeldsIndeterminate() throws Exception {
+  void noScopeClaimYeldsIndeterminate() {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn(null);
     PathAuthorizationResult result =
         pdp.authorizeRequest(newAuthorizationRequest(request, jwtAuth));
@@ -120,7 +120,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void noSaYeldsIndeterminate() throws Exception {
+  void noSaYeldsIndeterminate() {
 
     when(pathResolver.resolveStorageArea("/test/example")).thenReturn(null);
     PathAuthorizationResult result =
@@ -131,7 +131,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void noStorageScopesYeldsDeny() throws Exception {
+  void noStorageScopesYeldsDeny() {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid profile storage.read");
 
     PathAuthorizationResult result =
@@ -229,7 +229,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void replaceMethodsRequestsRequireStorageModifyOrCreate() throws Exception {
+  void replaceMethodsRequestsRequireStorageModifyOrCreate() {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/");
 
     for (String m : REPLACE_METHODS) {
@@ -273,7 +273,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void modifyMethodsRequestsRequireStorageModifyOrCreate() throws Exception {
+  void modifyMethodsRequestsRequireStorageModifyOrCreate() {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/ storage.create:/");
 
     for (String m : MODIFY_METHODS) {
@@ -296,7 +296,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void testLocalCopyRequiresStorageCreateOrModify() throws Exception {
+  void testLocalCopyRequiresStorageCreateOrModify() {
 
     when(request.getMethod()).thenReturn(COPY_METHOD);
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.modify:/");
@@ -313,7 +313,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void testPullTpcRequiresCreateOrModify() throws Exception {
+  void testPullTpcRequiresCreateOrModify() {
     when(request.getMethod()).thenReturn(COPY_METHOD);
     when(request.getHeader("Source")).thenReturn("https://remote.example/test/example");
     when(pathResolver.pathExists("/test/example")).thenReturn(true);
@@ -341,7 +341,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void testPushTpcRequiresRead() throws Exception {
+  void testPushTpcRequiresRead() {
     when(request.getMethod()).thenReturn(COPY_METHOD);
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.create:/ storage.modify:/");
     PathAuthorizationResult result =
@@ -357,7 +357,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void testMoveRequiresModify() throws Exception {
+  void testMoveRequiresModify() {
     when(request.getMethod()).thenReturn(MOVE_METHOD);
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/ storage.create:/");
     PathAuthorizationResult result =
@@ -373,7 +373,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void testModifyImpliesCreate() throws Exception {
+  void testModifyImpliesCreate() {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/ storage.modify:/");
     when(pathResolver.pathExists("/test/example")).thenReturn(false);
 
@@ -386,7 +386,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void testUnsupportedMethod() throws Exception {
+  void testUnsupportedMethod() {
     when(request.getMethod()).thenReturn("TRACE");
     assertThrows(IllegalArgumentException.class, () -> {
       pdp.authorizeRequest(newAuthorizationRequest(request, jwtAuth));
@@ -394,7 +394,7 @@ public class ScopePathAuthzPdpTests {
   }
 
   @Test
-  void testPathAuthzIsEnforced() throws Exception {
+  void testPathAuthzIsEnforced() {
     when(jwt.getClaimAsString(SCOPE_CLAIM)).thenReturn("openid storage.read:/subfolder");
     when(request.getMethod()).thenReturn("GET");
     PathAuthorizationResult result =


### PR DESCRIPTION
* HEAD and OPTIONS no more require storage.read
* Any storage.xxx scope can be used to allow HEAD or OPTIONS calls
* Introduced storage.stage as a superset of storage.read