### PR TITLE
Support for the 'entitlements' JWT claim

### DIFF
--- a/src/main/java/org/italiangrid/storm/webdav/oauth/GrantedAuthoritiesMapperSupport.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/GrantedAuthoritiesMapperSupport.java
@@ -34,8 +34,8 @@ public class GrantedAuthoritiesMapperSupport {
   protected final Multimap<String, GrantedAuthority> authzMap = ArrayListMultimap.create();
   protected final AuthorizationServerProperties authzServerProperties;
 
-  public static final String[] OAUTH_GROUP_CLAIM_NAMES = {"groups", "wlcg.groups", "entitlements"};
-  public static final String SCOPE_CLAIM_NAME = "scope";
+  protected static final String[] OAUTH_GROUP_CLAIM_NAMES = {"groups", "wlcg.groups", "entitlements"};
+  protected static final String SCOPE_CLAIM_NAME = "scope";
 
   protected final Set<GrantedAuthority> anonymousGrantedAuthorities = Sets.newHashSet();
 

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/GrantedAuthoritiesMapperSupport.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/GrantedAuthoritiesMapperSupport.java
@@ -34,7 +34,7 @@ public class GrantedAuthoritiesMapperSupport {
   protected final Multimap<String, GrantedAuthority> authzMap = ArrayListMultimap.create();
   protected final AuthorizationServerProperties authzServerProperties;
 
-  public static final String[] OAUTH_GROUP_CLAIM_NAMES = {"groups", "wlcg.groups"};
+  public static final String[] OAUTH_GROUP_CLAIM_NAMES = {"groups", "wlcg.groups", "entitlements"};
   public static final String SCOPE_CLAIM_NAME = "scope";
 
   protected final Set<GrantedAuthority> anonymousGrantedAuthorities = Sets.newHashSet();

--- a/src/test/java/org/italiangrid/storm/webdav/test/authz/integration/AuthorizationIntegrationTests.java
+++ b/src/test/java/org/italiangrid/storm/webdav/test/authz/integration/AuthorizationIntegrationTests.java
@@ -21,7 +21,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.italiangrid.storm.webdav.oauth.GrantedAuthoritiesMapperSupport.OAUTH_GROUP_CLAIM_NAMES;
 
 import java.net.URI;
 
@@ -229,7 +228,7 @@ public class AuthorizationIntegrationTests {
       .andExpect(status().isForbidden());
 
   }
-  
+
   @Test
   void writeAccessAsJwtWithAllowedClient() throws Exception {
     Jwt token = Jwt.withTokenValue("test")
@@ -280,6 +279,8 @@ public class AuthorizationIntegrationTests {
 
   @Test
   void readWriteAccessAsJwtWithAllowedGroup() throws Exception {
+
+    final String[] OAUTH_GROUP_CLAIM_NAMES = {"groups", "wlcg.groups", "entitlements"};
 
     for (String groupClaim : OAUTH_GROUP_CLAIM_NAMES) {
       Jwt token = Jwt.withTokenValue("test")


### PR DESCRIPTION
When the StoRM WevDAV fine-grained authorization is enabled, a policy applied on the JWT groups looks also for the _entitlements_ claim (together with _groups_ and _wlcg.groups_). The motivation is driven by the AARC Guideline [G069](https://zenodo.org/records/6533400).