### PR TITLE
Remove non-idiomatic use of Objects.isNull

### DIFF
--- a/src/main/java/org/italiangrid/storm/webdav/authn/AuthenticationUtils.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authn/AuthenticationUtils.java
@@ -15,10 +15,7 @@
  */
 package org.italiangrid.storm.webdav.authn;
 
-import static java.util.Objects.isNull;
-
 import java.util.Map;
-import java.util.Objects;
 
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -33,7 +30,7 @@ public class AuthenticationUtils {
   }
 
   public static String getPalatableSubject(Authentication authn) {
-    if (Objects.isNull(authn) || authn instanceof AnonymousAuthenticationToken) {
+    if (authn == null || authn instanceof AnonymousAuthenticationToken) {
       return "Anonymous user";
     } else if (authn instanceof OAuth2AuthenticationToken) {
       OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authn;
@@ -41,7 +38,7 @@ public class AuthenticationUtils {
 
       String subjectIssuer = String.format("%s @ %s", attributes.get("sub"), attributes.get("iss"));
 
-      if (!isNull(attributes.get("name"))) {
+      if (attributes.get("name") != null) {
         return (String) attributes.get("name");
       }
 

--- a/src/main/java/org/italiangrid/storm/webdav/authn/PrincipalHelper.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authn/PrincipalHelper.java
@@ -18,7 +18,6 @@ package org.italiangrid.storm.webdav.authn;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.italiangrid.storm.webdav.config.ServiceConfigurationProperties;
@@ -43,7 +42,7 @@ public class PrincipalHelper {
   }
 
   public String getPrincipalAsString(Authentication authn) {
-    if (Objects.isNull(authn) || authn instanceof AnonymousAuthenticationToken) {
+    if (authn == null || authn instanceof AnonymousAuthenticationToken) {
       return "anonymous";
     } else if (authn instanceof OAuth2AuthenticationToken) {
       OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authn;

--- a/src/main/java/org/italiangrid/storm/webdav/authz/VOMSPolicyService.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/VOMSPolicyService.java
@@ -15,7 +15,6 @@
  */
 package org.italiangrid.storm.webdav.authz;
 
-import static java.util.Objects.isNull;
 import static org.italiangrid.storm.webdav.authz.SAPermission.canRead;
 import static org.italiangrid.storm.webdav.authz.SAPermission.canWrite;
 
@@ -49,7 +48,7 @@ public class VOMSPolicyService implements AuthorizationPolicyService {
     voMapPerms = ArrayListMultimap.create();
 
     for (StorageAreaInfo sa : saConfig.getStorageAreaInfo()) {
-      if (!isNull(sa.vos())) {
+      if (sa.vos() != null) {
         for (String vo : sa.vos()) {
           voPerms.put(vo, canRead(sa.name()));
           voPerms.put(vo, canWrite(sa.name()));

--- a/src/main/java/org/italiangrid/storm/webdav/authz/pdp/PathAuthorizationPolicy.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/pdp/PathAuthorizationPolicy.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.authz.pdp;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
@@ -158,7 +157,7 @@ public class PathAuthorizationPolicy {
     }
 
     public PathAuthorizationPolicy build() {
-      if (Objects.isNull(id)) {
+      if (id == null) {
         id = UUID.randomUUID().toString();
       }
       return new PathAuthorizationPolicy(this);

--- a/src/main/java/org/italiangrid/storm/webdav/authz/pdp/WlcgStructuredPathAuthorizationPdp.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/pdp/WlcgStructuredPathAuthorizationPdp.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.authz.pdp;
 
 import static java.lang.String.format;
-import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
 import static org.italiangrid.storm.webdav.authz.pdp.PathAuthorizationResult.deny;
 import static org.italiangrid.storm.webdav.authz.pdp.PathAuthorizationResult.indeterminate;
@@ -181,13 +180,13 @@ public class WlcgStructuredPathAuthorizationPdp
 
     JwtAuthenticationToken jwtAuth = (JwtAuthenticationToken) authentication;
 
-    if (isNull(jwtAuth.getToken().getClaimAsString(SCOPE_CLAIM))) {
+    if (jwtAuth.getToken().getClaimAsString(SCOPE_CLAIM) == null) {
       return indeterminate(ERROR_INVALID_TOKEN_NO_SCOPE);
     }
 
     StorageAreaInfo sa = pathResolver.resolveStorageArea(requestPath);
 
-    if (isNull(sa)) {
+    if (sa == null) {
       return indeterminate(ERROR_SA_NOT_FOUND);
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/authz/pdp/principal/AnonymousUser.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/pdp/principal/AnonymousUser.java
@@ -15,8 +15,6 @@
  */
 package org.italiangrid.storm.webdav.authz.pdp.principal;
 
-import static java.util.Objects.isNull;
-
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
@@ -24,7 +22,7 @@ public class AnonymousUser implements PrincipalMatcher {
 
   @Override
   public boolean matchesPrincipal(Authentication authentication) {
-    return isNull(authentication) || authentication instanceof AnonymousAuthenticationToken;
+    return authentication == null || authentication instanceof AnonymousAuthenticationToken;
   }
 
   @Override

--- a/src/main/java/org/italiangrid/storm/webdav/authz/pdp/principal/AnyAuthenticatedUser.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/pdp/principal/AnyAuthenticatedUser.java
@@ -15,8 +15,6 @@
  */
 package org.italiangrid.storm.webdav.authz.pdp.principal;
 
-import static java.util.Objects.isNull;
-
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
@@ -24,7 +22,7 @@ public class AnyAuthenticatedUser implements PrincipalMatcher {
 
   @Override
   public boolean matchesPrincipal(Authentication authentication) {
-    return !isNull(authentication) && !(authentication instanceof AnonymousAuthenticationToken)
+    return authentication != null && !(authentication instanceof AnonymousAuthenticationToken)
         && authentication.isAuthenticated();
   }
 

--- a/src/main/java/org/italiangrid/storm/webdav/authz/pdp/principal/AuthorityHolder.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/pdp/principal/AuthorityHolder.java
@@ -15,8 +15,6 @@
  */
 package org.italiangrid.storm.webdav.authz.pdp.principal;
 
-import java.util.Objects;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -39,7 +37,7 @@ public class AuthorityHolder implements PrincipalMatcher {
   @Override
   public boolean matchesPrincipal(Authentication authentication) {
 
-    return !Objects.isNull(authentication) && authentication.getAuthorities()
+    return authentication != null && authentication.getAuthorities()
       .stream()
       .anyMatch(a -> a.getAuthority().equals(authority.getAuthority()));
   }

--- a/src/main/java/org/italiangrid/storm/webdav/authz/util/StructuredPathScopeMatcher.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/util/StructuredPathScopeMatcher.java
@@ -17,7 +17,6 @@ package org.italiangrid.storm.webdav.authz.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.util.Objects.nonNull;
 
 import java.nio.file.Path;
 import java.util.regex.Matcher;
@@ -33,7 +32,7 @@ public class StructuredPathScopeMatcher implements ScopeMatcher {
   public static final Logger LOG = LoggerFactory.getLogger(StructuredPathScopeMatcher.class);
 
   private static final Pattern POINT_DIR_MATCHER = Pattern.compile("\\.\\./?");
-  
+
   private static final Character SEP = ':';
   private static final String SEP_STR = SEP.toString();
 
@@ -55,24 +54,24 @@ public class StructuredPathScopeMatcher implements ScopeMatcher {
 
   @Override
   public boolean matchesScope(String scope) {
-    checkArgument(nonNull(scope), "scope must be non-null");
+    checkArgument(scope != null, "scope must be non-null");
 
     if (POINT_DIR_MATCHER.matcher(scope).find()) {
       throw new IllegalArgumentException("Scope contains relative path references");
     }
 
     Matcher prefixMatcher = prefixMatchPattern.matcher(scope);
-    
+
     boolean prefixMatches = prefixMatcher.find();
-    
+
     if (prefixMatches) {
       final String scopePath = scope.substring(prefix.length() + 1);
-      return pathMatchPattern.matcher(scopePath).matches(); 
+      return pathMatchPattern.matcher(scopePath).matches();
     } else {
       return false;
     }
   }
-  
+
   public boolean matchesPath(String path) {
     return pathMatchPattern.matcher(path).matches();
   }
@@ -81,7 +80,7 @@ public class StructuredPathScopeMatcher implements ScopeMatcher {
     Path targetPath = Path.of(path);
     return this.path.startsWith(targetPath) || matchesPath(path);
   }
-  
+
   public static StructuredPathScopeMatcher fromString(String scope) {
     final int sepIndex = scope.indexOf(SEP);
     final String prefix = scope.substring(0, sepIndex);
@@ -143,5 +142,5 @@ public class StructuredPathScopeMatcher implements ScopeMatcher {
   public String getPath() {
     return path.toString();
   }
-  
+
 }

--- a/src/main/java/org/italiangrid/storm/webdav/authz/voters/FineGrainedAuthzVoter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/voters/FineGrainedAuthzVoter.java
@@ -15,7 +15,6 @@
  */
 package org.italiangrid.storm.webdav.authz.voters;
 
-import static java.util.Objects.isNull;
 import static org.italiangrid.storm.webdav.authz.pdp.PathAuthorizationRequest.newAuthorizationRequest;
 
 import java.util.Collection;
@@ -48,7 +47,7 @@ public class FineGrainedAuthzVoter extends PathAuthzPdpVoterSupport {
     final String requestPath = getRequestPath(filter.getHttpRequest());
     StorageAreaInfo sa = resolver.resolveStorageArea(requestPath);
 
-    if (isNull(sa) || !sa.fineGrainedAuthzEnabled()) {
+    if (sa == null || !sa.fineGrainedAuthzEnabled()) {
       return ACCESS_ABSTAIN;
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/authz/voters/FineGrainedCopyMoveAuthzVoter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/voters/FineGrainedCopyMoveAuthzVoter.java
@@ -15,7 +15,6 @@
  */
 package org.italiangrid.storm.webdav.authz.voters;
 
-import static java.util.Objects.isNull;
 import static org.italiangrid.storm.webdav.server.servlet.WebDAVMethod.COPY;
 import static org.italiangrid.storm.webdav.server.servlet.WebDAVMethod.PUT;
 
@@ -68,7 +67,7 @@ public class FineGrainedCopyMoveAuthzVoter extends PathAuthzPdpVoterSupport {
       String destinationPath = getSanitizedPathFromUrl(destination);
       StorageAreaInfo sa = resolver.resolveStorageArea(destinationPath);
 
-      if (isNull(sa)) {
+      if (sa == null) {
         return ACCESS_ABSTAIN;
       }
 

--- a/src/main/java/org/italiangrid/storm/webdav/authz/voters/WlcgScopeAuthzCopyMoveVoter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/voters/WlcgScopeAuthzCopyMoveVoter.java
@@ -15,7 +15,6 @@
  */
 package org.italiangrid.storm.webdav.authz.voters;
 
-import static java.util.Objects.isNull;
 import static org.italiangrid.storm.webdav.server.servlet.WebDAVMethod.COPY;
 import static org.italiangrid.storm.webdav.server.servlet.WebDAVMethod.PUT;
 
@@ -74,7 +73,7 @@ public class WlcgScopeAuthzCopyMoveVoter extends PathAuthzPdpVoterSupport {
       String destinationPath = getSanitizedPathFromUrl(destination);
       StorageAreaInfo sa = resolver.resolveStorageArea(destinationPath);
 
-      if (isNull(sa)) {
+      if (sa == null) {
         return ACCESS_ABSTAIN;
       }
 

--- a/src/main/java/org/italiangrid/storm/webdav/authz/voters/WlcgScopeAuthzVoter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/authz/voters/WlcgScopeAuthzVoter.java
@@ -15,7 +15,6 @@
  */
 package org.italiangrid.storm.webdav.authz.voters;
 
-import static java.util.Objects.isNull;
 import static org.italiangrid.storm.webdav.authz.pdp.PathAuthorizationRequest.newAuthorizationRequest;
 
 import java.util.Collection;
@@ -53,7 +52,7 @@ public class WlcgScopeAuthzVoter extends PathAuthzPdpVoterSupport {
     final String requestPath = getRequestPath(filter.getHttpRequest());
     StorageAreaInfo sa = resolver.resolveStorageArea(requestPath);
 
-    if (isNull(sa)) {
+    if (sa == null) {
       return ACCESS_ABSTAIN;
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/config/validation/PrincipalValidator.java
+++ b/src/main/java/org/italiangrid/storm/webdav/config/validation/PrincipalValidator.java
@@ -17,7 +17,6 @@ package org.italiangrid.storm.webdav.config.validation;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
-import static java.util.Objects.isNull;
 import static org.italiangrid.storm.webdav.config.FineGrainedAuthzPolicyProperties.PrincipalProperties.PrincipalType.FQAN;
 import static org.italiangrid.storm.webdav.config.FineGrainedAuthzPolicyProperties.PrincipalProperties.PrincipalType.JWT_GROUP;
 import static org.italiangrid.storm.webdav.config.FineGrainedAuthzPolicyProperties.PrincipalProperties.PrincipalType.JWT_SCOPE;
@@ -63,8 +62,8 @@ public class PrincipalValidator implements
       ConstraintValidatorContext context) {
 
     Collection<String> requiredArgs = REQUIRED_ARGS.get(value.getType());
-    
-    if (isNull(requiredArgs) || requiredArgs.isEmpty()) {
+
+    if (requiredArgs == null || requiredArgs.isEmpty()) {
       return true;
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/metrics/StorageAreaStatsFilter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/metrics/StorageAreaStatsFilter.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.metrics;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static java.util.Objects.isNull;
 
 import java.io.IOException;
 
@@ -52,7 +51,7 @@ public class StorageAreaStatsFilter implements Filter, TpcUtils {
   private void updateStats(HttpServletRequest request, HttpServletResponse response) {
     StorageAreaInfo sa = resolver.resolveStorageArea(getSerlvetRequestPath(request));
 
-    if (!isNull(sa)) {
+    if (sa != null) {
       String prefix = name(SA_KEY, sa.name(), REQUESTS_KEY);
       registry.meter(prefix).mark();
       if (response.getStatus() >= 400) {

--- a/src/main/java/org/italiangrid/storm/webdav/milton/StoRMFileResource.java
+++ b/src/main/java/org/italiangrid/storm/webdav/milton/StoRMFileResource.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.milton;
 
 import static io.milton.property.PropertySource.PropertyAccessibility.READ_ONLY;
-import static java.util.Objects.isNull;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -126,7 +125,7 @@ public class StoRMFileResource extends StoRMResource
   protected void validateRange(Range range) {
     long fileSize = getFile().length();
 
-    if (isNull(range.getStart())) {
+    if (range.getStart() == null) {
       throw new StoRMWebDAVError("Invalid range: range start not defined");
     }
 
@@ -134,7 +133,7 @@ public class StoRMFileResource extends StoRMResource
       throw new StoRMWebDAVError("Invalid range: range start out of bounds");
     }
 
-    if (!isNull(range.getFinish()) && range.getFinish() > fileSize) {
+    if (range.getFinish() != null && range.getFinish() > fileSize) {
       throw new StoRMWebDAVError("Invalid range: range end out of bounds");
     }
   }
@@ -147,7 +146,7 @@ public class StoRMFileResource extends StoRMResource
     long rangeStart = range.getStart();
     long rangeEnd = getFile().length();
 
-    if (!isNull(range.getFinish()) && range.getFinish() < rangeEnd) {
+    if (range.getFinish() != null && range.getFinish() < rangeEnd) {
       rangeEnd = range.getFinish();
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/GrantedAuthoritiesMapperSupport.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/GrantedAuthoritiesMapperSupport.java
@@ -15,8 +15,6 @@
  */
 package org.italiangrid.storm.webdav.oauth;
 
-import static java.util.Objects.isNull;
-
 import java.util.Collection;
 import java.util.Set;
 
@@ -48,7 +46,7 @@ public class GrantedAuthoritiesMapperSupport {
     authzServerProperties = props.getAuthzServer();
 
     for (StorageAreaInfo sa : conf.getStorageAreaInfo()) {
-      if (!isNull(sa.orgs())) {
+      if (sa.orgs() != null) {
         sa.orgs().forEach(i -> addSaGrantedAuthorities(sa, i));
       }
     }

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/StormJwtAuthoritiesConverter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/StormJwtAuthoritiesConverter.java
@@ -18,7 +18,6 @@ package org.italiangrid.storm.webdav.oauth;
 import static org.italiangrid.storm.webdav.oauth.authzserver.jwt.DefaultJwtTokenIssuer.CLAIM_AUTHORITIES;
 
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -58,7 +57,7 @@ public class StormJwtAuthoritiesConverter extends GrantedAuthoritiesMapperSuppor
     Optional.ofNullable(
         jwt.getClaimAsStringList(CLAIM_AUTHORITIES))
       .ifPresent(a -> a.forEach(at -> authorities.add(SAPermission.fromString(at))));
-      
+
     return authorities;
   }
 
@@ -66,7 +65,7 @@ public class StormJwtAuthoritiesConverter extends GrantedAuthoritiesMapperSuppor
 
     Set<GrantedAuthority> scopeAuthorities = Sets.newHashSet();
 
-    if (!Objects.isNull(jwt.getClaimAsString(SCOPE_CLAIM_NAME))) {
+    if (jwt.getClaimAsString(SCOPE_CLAIM_NAME) != null) {
       String tokenIssuer = jwt.getClaimAsString(JwtClaimNames.ISS);
 
       String[] scopes = jwt.getClaimAsString(SCOPE_CLAIM_NAME).split(" ");

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/authzserver/jwt/DefaultJwtTokenIssuer.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/authzserver/jwt/DefaultJwtTokenIssuer.java
@@ -15,7 +15,6 @@
  */
 package org.italiangrid.storm.webdav.oauth.authzserver.jwt;
 
-import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
 
 import java.time.Clock;
@@ -98,7 +97,7 @@ public class DefaultJwtTokenIssuer implements SignedJwtTokenIssuer {
     Instant defaultExpiration = now.plusSeconds(properties.getMaxTokenLifetimeSec());
     Instant expiration = defaultExpiration;
 
-    if (!isNull(request.getLifetime()) && request.getLifetime() > 0) {
+    if (request.getLifetime() != null && request.getLifetime() > 0) {
       requestedExpiration = Optional.of(now.plusSeconds(request.getLifetime()));
     }
 
@@ -126,19 +125,19 @@ public class DefaultJwtTokenIssuer implements SignedJwtTokenIssuer {
   public SignedJWT createAccessToken(AccessTokenRequest request, Authentication authentication) {
 
     Set<GrantedAuthority> tokenAuthorities = Sets.newHashSet();
-    
+
     Set<GrantedAuthority> saAuthorities = policyService.getSAPermissions(authentication);
     tokenAuthorities.addAll(saAuthorities);
-    
+
     tokenAuthorities.addAll(authentication.getAuthorities());
-    
+
     JWTClaimsSet.Builder claimsSet = new JWTClaimsSet.Builder();
 
     claimsSet.issuer(properties.getIssuer());
     claimsSet.audience(properties.getIssuer());
     claimsSet.subject(authentication.getName());
     claimsSet.expirationTime(computeTokenExpirationTimestamp(request, authentication));
-    
+
     claimsSet.claim(CLAIM_AUTHORITIES,
         tokenAuthorities.stream().map(Object::toString).collect(toList()));
 
@@ -162,7 +161,7 @@ public class DefaultJwtTokenIssuer implements SignedJwtTokenIssuer {
 
     claimsSet.subject(helper.getPrincipalAsString(authentication));
     claimsSet.expirationTime(computeResourceTokenExpiration(request));
-    
+
     claimsSet.claim(PATH_CLAIM, request.getPath());
     claimsSet.claim(PERMS_CLAIM, request.getPermission().name());
     claimsSet.claim(ORIGIN_CLAIM, request.getOrigin());

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/utils/DefaultOidcConfigurationFetcher.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/utils/DefaultOidcConfigurationFetcher.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 
 import org.italiangrid.storm.webdav.config.OAuthProperties;
 import org.slf4j.Logger;
@@ -100,7 +99,7 @@ public class DefaultOidcConfigurationFetcher implements OidcConfigurationFetcher
       throw new OidcConfigurationResolutionError(
           format("Received status code: %s", response.getStatusCodeValue()));
     }
-    if (Objects.isNull(response.getBody())) {
+    if (response.getBody() == null) {
       throw new OidcConfigurationResolutionError("Received null body");
     }
     metadataChecks(issuer, response.getBody());

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/validator/AudienceValidator.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/validator/AudienceValidator.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.oauth.validator;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.isNull;
 
 import java.util.Set;
 
@@ -45,7 +44,7 @@ public class AudienceValidator implements OAuth2TokenValidator<Jwt> {
       OAuth2TokenValidatorResult.failure(INVALID_AUDIENCE_ERROR);
 
   public AudienceValidator(AuthorizationServer server) {
-    checkArgument(!isNull(server.getAudiences()), "null audiences");
+    checkArgument(server.getAudiences() != null, "null audiences");
     checkArgument(!server.getAudiences().isEmpty(), "empty audiences");
     requiredAudiences.addAll(server.getAudiences());
   }
@@ -53,7 +52,7 @@ public class AudienceValidator implements OAuth2TokenValidator<Jwt> {
   @Override
   public OAuth2TokenValidatorResult validate(Jwt jwt) {
 
-    if (isNull(jwt.getAudience()) || jwt.getAudience().isEmpty()) {
+    if (jwt.getAudience() == null || jwt.getAudience().isEmpty()) {
       return SUCCESS;
     }
 
@@ -65,7 +64,7 @@ public class AudienceValidator implements OAuth2TokenValidator<Jwt> {
 
     LOG.debug("Audience check failed. Token audience: {}, local audience: {}", jwt.getAudience(),
         requiredAudiences);
-    
+
     return INVALID_AUDIENCE;
   }
 

--- a/src/main/java/org/italiangrid/storm/webdav/oauth/validator/WlcgProfileValidator.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oauth/validator/WlcgProfileValidator.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.oauth.validator;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.util.Objects.isNull;
 
 import java.util.Collections;
 import java.util.Set;
@@ -81,23 +80,23 @@ public class WlcgProfileValidator implements OAuth2TokenValidator<Jwt> {
       return OAuth2TokenValidatorResult.failure(MISSING_SCOPE);
     }
 
-    if (isNull(token.getNotBefore())) {
+    if (token.getNotBefore() == null) {
       return OAuth2TokenValidatorResult.failure(MISSING_NBF);
     }
 
-    if (isNull(token.getExpiresAt())) {
+    if (token.getExpiresAt() == null) {
       return OAuth2TokenValidatorResult.failure(MISSING_EXP);
     }
 
-    if (isNull(token.getSubject())) {
+    if (token.getSubject() == null) {
       return OAuth2TokenValidatorResult.failure(MISSING_SUB);
     }
 
-    if (isNull(token.getAudience()) || token.getAudience().isEmpty()) {
+    if (token.getAudience() == null || token.getAudience().isEmpty()) {
       return OAuth2TokenValidatorResult.failure(MISSING_AUD);
     }
-    
-    if (isNull(token.getId())) {
+
+    if (token.getId() == null) {
       return OAuth2TokenValidatorResult.failure(MISSING_JTI);
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/oidc/ClientRegistrationCacheLoader.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oidc/ClientRegistrationCacheLoader.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.oidc;
 
 import static java.lang.String.format;
-import static java.util.Objects.isNull;
 
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -111,7 +110,7 @@ public class ClientRegistrationCacheLoader extends CacheLoader<String, ClientReg
   public ClientRegistration load(String key) throws Exception {
     OAuth2ClientProperties.Registration reg = clientProperties.getRegistration().get(key);
 
-    if (isNull(reg)) {
+    if (reg == null) {
       return null;
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/oidc/OidcGrantedAuthoritiesMapper.java
+++ b/src/main/java/org/italiangrid/storm/webdav/oidc/OidcGrantedAuthoritiesMapper.java
@@ -15,8 +15,6 @@
  */
 package org.italiangrid.storm.webdav.oidc;
 
-import static java.util.Objects.isNull;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -51,7 +49,7 @@ public class OidcGrantedAuthoritiesMapper extends GrantedAuthoritiesMapperSuppor
 
     for (String groupClaimName : OAUTH_GROUP_CLAIM_NAMES) {
       List<String> groups = userAuthority.getIdToken().getClaimAsStringList(groupClaimName);
-      if (!isNull(groups)) {
+      if (groups != null) {
         groups.stream()
           .map(g -> new JwtGroupAuthority(idTokenIssuer, g))
           .forEach(groupAuthorities::add);

--- a/src/main/java/org/italiangrid/storm/webdav/redirector/RedirectFilter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/redirector/RedirectFilter.java
@@ -17,7 +17,6 @@ package org.italiangrid.storm.webdav.redirector;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Objects;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -60,7 +59,7 @@ public class RedirectFilter implements Filter, TpcUtils, RedirectConstants {
     SecurityContext context = resolveSecurityContext();
 
     if (isRedirectable(req)) {
-      
+
       res.setHeader(LOCATION, service.buildRedirect(context.getAuthentication(), req, res));
       res.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
 
@@ -73,7 +72,7 @@ public class RedirectFilter implements Filter, TpcUtils, RedirectConstants {
   private SecurityContext resolveSecurityContext() {
     SecurityContext context = SecurityContextHolder.getContext();
 
-    if (Objects.isNull(context)) {
+    if (context == null) {
       throw new RedirectError("Failed to enstabilish a valid security context");
     }
 
@@ -103,7 +102,7 @@ public class RedirectFilter implements Filter, TpcUtils, RedirectConstants {
     String path = getSerlvetRequestPath(req);
     Path p = pathResolver.getPath(path);
 
-    if (Objects.isNull(p)) {
+    if (p == null) {
       return false;
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/server/DefaultPathResolver.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/DefaultPathResolver.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.server;
 
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
-import static java.util.Objects.isNull;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -67,13 +66,13 @@ public class DefaultPathResolver implements PathResolver {
   @Override
   public String resolvePath(String pathInContext) {
 
-    if (isNull(pathInContext)) {
+    if (pathInContext == null) {
       return null;
     }
 
     Path p = getPath(pathInContext);
 
-    if (!isNull(p)) {
+    if (p != null) {
       return p.toString();
     }
 
@@ -102,7 +101,7 @@ public class DefaultPathResolver implements PathResolver {
   public boolean pathExists(String pathInContext) {
     String resolvedPath = resolvePath(pathInContext);
 
-    if (isNull(resolvedPath)) {
+    if (resolvedPath == null) {
       return false;
     }
 
@@ -112,7 +111,7 @@ public class DefaultPathResolver implements PathResolver {
   @Override
   public Path getPath(String pathInContext) {
 
-    if (isNull(pathInContext)) {
+    if (pathInContext == null) {
       return null;
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/server/TLSServerConnectorBuilder.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/TLSServerConnectorBuilder.java
@@ -15,8 +15,6 @@
  */
 package org.italiangrid.storm.webdav.server;
 
-import static java.util.Objects.isNull;
-
 import java.io.File;
 import java.io.IOException;
 import java.security.KeyManagementException;
@@ -56,7 +54,7 @@ import eu.emi.security.authn.x509.impl.PEMCredential;
 /**
  * A builder that configures a Jetty server TLS connector integrated with CANL
  * {@link X509CertChainValidatorExt} certificate validation services.
- * 
+ *
  */
 public class TLSServerConnectorBuilder {
 
@@ -193,7 +191,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Returns an instance of the {@link TLSServerConnectorBuilder}.
-   * 
+   *
    * @param s the {@link Server} for which the connector is being created
    * @param certificateValidator a {@link X509CertChainValidatorExt} used to validate certificates
    * @return an instance of the {@link TLSServerConnectorBuilder}
@@ -206,7 +204,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Private ctor.
-   * 
+   *
    * @param s the {@link Server} for which the connector is being created
    * @param certificateValidator a {@link X509CertChainValidatorExt} used to validate certificates
    */
@@ -254,7 +252,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Configures SSL session parameters for the jetty {@link SslContextFactory}.
-   * 
+   *
    * @param contextFactory the {@link SslContextFactory} being configured
    */
   private void configureContextFactory(SslContextFactory.Server contextFactory) {
@@ -296,7 +294,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Builds a default {@link HttpConfiguration} for the TLS-enabled connector being created
-   * 
+   *
    * @return the default {@link HttpConfiguration}
    */
   private HttpConfiguration defaultHttpConfiguration() {
@@ -323,7 +321,7 @@ public class TLSServerConnectorBuilder {
   /**
    * Gives access to the {@link HttpConfiguration} used for the TLS-enabled connector being created.
    * If the configuration is not set, it creates it using {@link #defaultHttpConfiguration()}.
-   * 
+   *
    * @return the {@link HttpConfiguration} being used for the TLS-enabled connector.
    */
   public HttpConfiguration httpConfiguration() {
@@ -338,7 +336,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Sets the port for the connector being created.
-   * 
+   *
    * @param port the port for the connector
    * @return this builder
    */
@@ -350,7 +348,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Sets the certificate file for the connector being created.
-   * 
+   *
    * @param certificateFile the certificate file
    * @return this builder
    */
@@ -362,7 +360,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Sets the certificate key file for the connector being created.
-   * 
+   *
    * @param certificateKeyFile the certificate key file
    * @return this builder
    */
@@ -374,7 +372,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * The the certificate key password for the connector being built
-   * 
+   *
    * @param certificateKeyPassword the certificate key password
    * @return this builder
    */
@@ -387,7 +385,7 @@ public class TLSServerConnectorBuilder {
   /**
    * Sets the {@link SslContextFactory#setNeedClientAuth(boolean)} parameter for the connector being
    * created.
-   * 
+   *
    * @param needClientAuth true if client authentication is required
    * @return this builder
    */
@@ -400,7 +398,7 @@ public class TLSServerConnectorBuilder {
   /**
    * Sets the {@link SslContextFactory#setWantClientAuth(boolean)} parameter for the connector being
    * created.
-   * 
+   *
    * @param wantClientAuth true if client authentication is wanted
    * @return this builder
    */
@@ -412,7 +410,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Sets SSL included protocols. See {@link SslContextFactory#setIncludeProtocols(String...)}.
-   * 
+   *
    * @param includeProtocols the array of included protocol names
    * @return this builder
    */
@@ -424,7 +422,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Sets SSL excluded protocols. See {@link SslContextFactory#setExcludeProtocols(String...)}.
-   * 
+   *
    * @param excludeProtocols the array of excluded protocol names
    * @return this builder
    */
@@ -436,7 +434,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Sets the SSL included cipher suites.
-   * 
+   *
    * @param includeCipherSuites the array of included cipher suites.
    * @return this builder
    */
@@ -448,7 +446,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Sets the SSL ecluded cipher suites.
-   * 
+   *
    * @param excludeCipherSuites the array of excluded cipher suites.
    * @return this builder
    */
@@ -460,7 +458,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Sets the {@link HttpConfiguration} for the connector being built.
-   * 
+   *
    * @param conf the {@link HttpConfiguration} to use
    * @return this builder
    */
@@ -472,7 +470,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Sets the {@link KeyManager} for the connector being built.
-   * 
+   *
    * @param km the {@link KeyManager} to use
    * @return this builder
    */
@@ -539,7 +537,7 @@ public class TLSServerConnectorBuilder {
 
       if (useConscrypt) {
 
-        if (isNull(Security.getProvider(CONSCRYPT_PROVIDER))) {
+        if (Security.getProvider(CONSCRYPT_PROVIDER) == null) {
           Security.addProvider(new OpenSSLProvider());
         }
 
@@ -564,7 +562,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Builds a {@link ServerConnector} based on the {@link TLSServerConnectorBuilder} parameters
-   * 
+   *
    * @return a {@link ServerConnector}
    */
   public ServerConnector build() {
@@ -637,7 +635,7 @@ public class TLSServerConnectorBuilder {
 
   /**
    * Checks that file exists and is readable.
-   * 
+   *
    * @param f the {@link File} to be checked
    * @param prefix A prefix string for the error message, in case the file does not exist and is not
    *        readable

--- a/src/main/java/org/italiangrid/storm/webdav/server/servlet/MiltonFilter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/servlet/MiltonFilter.java
@@ -15,8 +15,6 @@
  */
 package org.italiangrid.storm.webdav.server.servlet;
 
-import static java.util.Objects.isNull;
-
 import java.io.IOException;
 import java.util.Set;
 
@@ -101,7 +99,7 @@ public class MiltonFilter implements Filter {
 
     servletContext = config.getServletContext();
 
-    if (isNull(miltonHTTPManager)) {
+    if (miltonHTTPManager == null) {
       initMiltonHTTPManager(servletContext);
     }
 

--- a/src/main/java/org/italiangrid/storm/webdav/spring/AppConfig.java
+++ b/src/main/java/org/italiangrid/storm/webdav/spring/AppConfig.java
@@ -15,7 +15,6 @@
  */
 package org.italiangrid.storm.webdav.spring;
 
-import static java.util.Objects.isNull;
 import static org.italiangrid.storm.webdav.server.TLSServerConnectorBuilder.CONSCRYPT_PROVIDER;
 
 import java.io.IOException;
@@ -247,7 +246,7 @@ public class AppConfig implements TransferConstants {
     SSLContext ctx;
 
     if (props.isUseConscrypt()) {
-      if (isNull(Security.getProvider(CONSCRYPT_PROVIDER))) {
+      if (Security.getProvider(CONSCRYPT_PROVIDER) == null) {
         Security.addProvider(new OpenSSLProvider());
       }
       ctx = SSLContext.getInstance(props.getTlsProtocol(), CONSCRYPT_PROVIDER);

--- a/src/main/java/org/italiangrid/storm/webdav/tpc/StaticHostListLocalURLService.java
+++ b/src/main/java/org/italiangrid/storm/webdav/tpc/StaticHostListLocalURLService.java
@@ -17,7 +17,6 @@ package org.italiangrid.storm.webdav.tpc;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Objects.isNull;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -42,8 +41,7 @@ public class StaticHostListLocalURLService implements LocalURLService {
 
       URI uri = new URI(url);
 
-      if (isNull(uri.getScheme())
-          || (!isNull(uri.getHost()) && uri.getHost().equals("localhost"))) {
+      if (uri.getScheme() == null || (uri.getHost() != null && uri.getHost().equals("localhost"))) {
         return true;
       }
 

--- a/src/main/java/org/italiangrid/storm/webdav/tpc/TransferFilterSupport.java
+++ b/src/main/java/org/italiangrid/storm/webdav/tpc/TransferFilterSupport.java
@@ -16,7 +16,6 @@
 package org.italiangrid.storm.webdav.tpc;
 
 import static java.lang.String.format;
-import static java.util.Objects.isNull;
 import static javax.servlet.http.HttpServletResponse.SC_PRECONDITION_FAILED;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
@@ -131,7 +130,7 @@ public class TransferFilterSupport implements TransferConstants, TpcUtils {
 
 
   protected boolean isSupportedTransferURI(URI uri) {
-    return SUPPORTED_PROTOCOLS.contains(uri.getScheme()) && !isNull(uri.getPath());
+    return SUPPORTED_PROTOCOLS.contains(uri.getScheme()) && uri.getPath() != null;
   }
 
   protected boolean validTransferURI(String xferUri) {

--- a/src/main/java/org/italiangrid/storm/webdav/tpc/http/GetResponseHandler.java
+++ b/src/main/java/org/italiangrid/storm/webdav/tpc/http/GetResponseHandler.java
@@ -15,8 +15,6 @@
  */
 package org.italiangrid.storm.webdav.tpc.http;
 
-import static java.util.Objects.isNull;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -70,7 +68,7 @@ public class GetResponseHandler extends ResponseHandlerSupport
 
     final InputStream inStream = entity.getContent();
 
-    if (!isNull(inStream)) {
+    if (inStream != null) {
       try {
         int l;
         final byte[] tmp = new byte[bufferSize];

--- a/src/main/java/org/italiangrid/storm/webdav/tpc/http/ResponseHandlerSupport.java
+++ b/src/main/java/org/italiangrid/storm/webdav/tpc/http/ResponseHandlerSupport.java
@@ -15,8 +15,6 @@
  */
 package org.italiangrid.storm.webdav.tpc.http;
 
-import static java.util.Objects.isNull;
-
 import java.util.Map;
 
 import org.apache.http.StatusLine;
@@ -30,9 +28,9 @@ public abstract class ResponseHandlerSupport {
   protected ResponseHandlerSupport(Map<String, String> mdcContextMap) {
     this.mdcContextMap = mdcContextMap;
   }
-  
+
   protected void setupMDC() {
-    if (!isNull(mdcContextMap)) {
+    if (mdcContextMap != null) {
       MDC.setContextMap(mdcContextMap);
     }
   }

--- a/src/main/java/org/italiangrid/storm/webdav/tpc/transfer/impl/TransferRequestImpl.java
+++ b/src/main/java/org/italiangrid/storm/webdav/tpc/transfer/impl/TransferRequestImpl.java
@@ -18,7 +18,6 @@ package org.italiangrid.storm.webdav.tpc.transfer.impl;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.italiangrid.storm.webdav.scitag.SciTag;
@@ -165,7 +164,7 @@ public abstract class TransferRequestImpl implements TransferRequest {
   @Override
   public Duration duration() {
 
-    if (Objects.isNull(startTime) || Objects.isNull(endTime)) {
+    if (startTime == null || endTime == null) {
       LOG.debug("Duration called before end of trasnfer, will return ZERO");
       return Duration.ZERO;
     }

--- a/src/test/java/org/italiangrid/storm/webdav/test/utils/voms/VOMSSecurityContextBuilder.java
+++ b/src/test/java/org/italiangrid/storm/webdav/test/utils/voms/VOMSSecurityContextBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.italiangrid.storm.webdav.test.utils.voms;
 
-import static java.util.Objects.isNull;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
@@ -64,7 +63,7 @@ public class VOMSSecurityContextBuilder {
   public VOMSSecurityContextBuilder vos(String... vos) {
 
     for (String vo : vos) {
-      if (!isNull(authorities)) {
+      if (authorities != null) {
         authorities.add(new VOMSVOAuthority(vo));
 
       } else {
@@ -76,7 +75,7 @@ public class VOMSSecurityContextBuilder {
 
   public VOMSSecurityContextBuilder saReadPermissions(String... sas) {
     for (String sa : sas) {
-      if (!isNull(authorities)) {
+      if (authorities != null) {
         authorities.add(SAPermission.canRead(sa));
       } else {
         authorities = Lists.newArrayList(SAPermission.canRead(sa));
@@ -87,7 +86,7 @@ public class VOMSSecurityContextBuilder {
 
   public VOMSSecurityContextBuilder saWritePermissions(String... sas) {
     for (String sa : sas) {
-      if (!isNull(authorities)) {
+      if (authorities != null) {
         authorities.add(SAPermission.canWrite(sa));
       } else {
         authorities = Lists.newArrayList(SAPermission.canWrite(sa));


### PR DESCRIPTION
This method exists to be used as a Predicate, filter(Objects::isNull)