### PR TITLE
Make namespace checking mode configurable

### DIFF
--- a/src/main/java/org/italiangrid/storm/webdav/config/ServiceConfiguration.java
+++ b/src/main/java/org/italiangrid/storm/webdav/config/ServiceConfiguration.java
@@ -57,4 +57,6 @@ public interface ServiceConfiguration {
 
   public String getTlsProtocol();
 
+  public String getNamespaceCheckingMode();
+
 }

--- a/src/main/java/org/italiangrid/storm/webdav/config/ServiceConfigurationProperties.java
+++ b/src/main/java/org/italiangrid/storm/webdav/config/ServiceConfigurationProperties.java
@@ -19,6 +19,7 @@ import static org.italiangrid.storm.webdav.config.ServiceConfigurationProperties
 
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -363,6 +364,9 @@ public class ServiceConfigurationProperties implements ServiceConfiguration {
     @NotBlank
     String protocol = "TLS";
 
+    @NotBlank
+    String namespaceCheckingMode = "EUGRIDPMA_AND_GLOBUS_REQUIRE";
+
     public String getCertificatePath() {
       return certificatePath;
     }
@@ -425,6 +429,14 @@ public class ServiceConfigurationProperties implements ServiceConfiguration {
 
     public void setProtocol(String protocol) {
       this.protocol = protocol;
+    }
+
+    public void setNamespaceCheckingMode(String checkingMode) {
+      this.namespaceCheckingMode = Objects.requireNonNull(checkingMode);
+    }
+
+    public String getNamespaceCheckingMode() {
+      return namespaceCheckingMode;
     }
   }
 
@@ -784,6 +796,11 @@ public class ServiceConfigurationProperties implements ServiceConfiguration {
   @Override
   public boolean requireClientCertificateAuthentication() {
     return getTls().isRequireClientCert();
+  }
+
+  @Override
+  public String getNamespaceCheckingMode() {
+        return getTls().getNamespaceCheckingMode();
   }
 
 

--- a/src/main/java/org/italiangrid/storm/webdav/spring/AppConfig.java
+++ b/src/main/java/org/italiangrid/storm/webdav/spring/AppConfig.java
@@ -208,7 +208,9 @@ public class AppConfig implements TransferConstants {
     long refreshInterval =
         TimeUnit.SECONDS.toMillis(configuration.getTrustAnchorsRefreshIntervalInSeconds());
 
-    return builder.namespaceChecks(NamespaceCheckingMode.EUGRIDPMA_AND_GLOBUS_REQUIRE)
+    NamespaceCheckingMode checkingMode = NamespaceCheckingMode.valueOf(configuration.getNamespaceCheckingMode());
+
+    return builder.namespaceChecks(checkingMode)
       .crlChecks(CrlCheckingMode.IF_VALID)
       .ocspChecks(OCSPCheckingMode.IGNORE)
       .lazyAnchorsLoading(false)


### PR DESCRIPTION
Motivation:

For HTTP-TPC, the checking of Subject DN makes no sense, as the identity being asserted by the EEC is the DNS name of the host.

Modification:

Add configation option to allow different checking modes, as supported by the CaNL library.  The default option, if none specified, is the existing mode `EUGRIDPMA_AND_GLOBUS_REQUIRE`, providing backwards compatibility.

Result:

No user or admin visible changes by default.  StoRM-WebDAV now supports an admin configuring the namespace checking mode via:

    storm:
	tls:
            namespace-checking-mode: IGNORE