### PR TITLE
update milton version from v2.7.1.7 to v2.8.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
     <voms-api-java.version>3.3.3</voms-api-java.version>
-    <milton.version>2.7.1.7</milton.version>
+    <milton.version>2.8.0.3</milton.version>
 
     <commons-lang.version>2.3</commons-lang.version>
     <commons-cli.version>1.2</commons-cli.version>


### PR DESCRIPTION
Motivation:

The current version of Milton is ancient.  The git commit that updated the version to v2.7.1.7 (f50f6c3e3) was made 2016-07-01.  At this time, the Milton release process was rather haphazard, with no git tags and no jar files uploaded to Maven central.  This makes building StoRM WebDAV difficult.

Milton v2.8.0.3 was released 2020-09-23 and is the first version with a reasonable release process: git tags and jar files uploaded to Maven central.  The online Milton release notes also start with this version.

Although v2.8.0.3 is now over four years old, updating to this version fixes build problems while limiting the risk (of breaking changes) from the library upgrade.

Modification:

Update pom.xml to use the newer version.

Result:

No user- or admin observable changes.