### PR TITLE
Include a `Server` HTTP response header with details of StoRM-WebDAV

### DIFF
--- a/src/main/java/org/italiangrid/storm/webdav/server/servlet/ServerResponseHeaderFilter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/servlet/ServerResponseHeaderFilter.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare, 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.italiangrid.storm.webdav.server.servlet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.jar.Attributes;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Add 'Server' header response, using StoRM-WebDAV version (taken from the
+ * .jar file) and an instance ID that is (with high likelihood) different
+ * between any two invocations of StoRM-WebDAV instances.
+ */
+public class ServerResponseHeaderFilter implements Filter {
+
+    private static final int INSTANCE_ID_LENGTH = 4;
+
+    private static final String SERVER_HEADER_VALUE = "StoRM-WebDAV/" + lookupStormVersion()
+            + " (instance=" + calculateInstanceIdentifier() + ")";
+
+    private static String lookupStormVersion() {
+        ProtectionDomain pd = ServerResponseHeaderFilter.class.getProtectionDomain();
+        CodeSource cs = pd.getCodeSource();
+        URL u = cs.getLocation();
+
+        Optional<String> maybeVersion = Optional.empty();
+        try (InputStream is = u.openStream()) {
+            JarInputStream jis = new JarInputStream(is);
+            Manifest m = jis.getManifest();
+            if (m != null) {
+                Attributes attributes = m.getMainAttributes();
+                String value = attributes.getValue("Implementation-Version");
+                maybeVersion = Optional.ofNullable(value);
+            }
+        } catch (IOException ignored) {
+        }
+        return maybeVersion.orElse("unknown-version");
+    }
+
+    private static String calculateInstanceIdentifier() {
+        byte[] in = ByteBuffer.allocate(Long.BYTES)
+                .putLong(System.currentTimeMillis())
+                .array();
+        byte[] encodedBytes = Base64.getEncoder().withoutPadding().encode(in);
+        String encoded = new String(encodedBytes);
+        return encoded.substring(encoded.length() - INSTANCE_ID_LENGTH);
+    }
+
+    private void specifyServerHeader(HttpServletResponse response) {
+        response.setHeader("Server", SERVER_HEADER_VALUE);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+            FilterChain chain) throws IOException, ServletException {
+
+        if (response instanceof HttpServletResponse) {
+            // Set the header now, in case the response is committed before
+            // chain.doFilter returns.
+            specifyServerHeader((HttpServletResponse)response);
+        }
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            if (response instanceof HttpServletResponse) {
+                // Set the header now, in case the response is not yet
+                // committed.  This allows the code to override any
+                // {@literal Server} header value specified earlier.
+                specifyServerHeader((HttpServletResponse)response);
+            }
+        }
+    }
+}

--- a/src/main/java/org/italiangrid/storm/webdav/spring/web/ServletConfiguration.java
+++ b/src/main/java/org/italiangrid/storm/webdav/spring/web/ServletConfiguration.java
@@ -40,6 +40,7 @@ import org.italiangrid.storm.webdav.server.servlet.MiltonFilter;
 import org.italiangrid.storm.webdav.server.servlet.MoveRequestSanityChecksFilter;
 import org.italiangrid.storm.webdav.server.servlet.SAIndexServlet;
 import org.italiangrid.storm.webdav.server.servlet.SciTagFilter;
+import org.italiangrid.storm.webdav.server.servlet.ServerResponseHeaderFilter;
 import org.italiangrid.storm.webdav.server.servlet.StoRMServlet;
 import org.italiangrid.storm.webdav.server.servlet.resource.StormResourceService;
 import org.italiangrid.storm.webdav.server.tracing.LogbackAccessAuthnInfoFilter;
@@ -80,6 +81,7 @@ public class ServletConfiguration {
   static final int MOVE_FILTER_ORDER = DEFAULT_FILTER_ORDER + 1008;
   static final int DELETE_FILTER_ORDER = DEFAULT_FILTER_ORDER + 1009;
   static final int MILTON_FILTER_ORDER = DEFAULT_FILTER_ORDER + 1010;
+  static final int SERVER_FILTER_ORDER = DEFAULT_FILTER_ORDER - 100;
   static final int STATS_FILTER_ORDER = DEFAULT_FILTER_ORDER - 200;
 
   @Bean
@@ -219,6 +221,14 @@ public class ServletConfiguration {
     return filter;
   }
 
+  @Bean
+  FilterRegistrationBean<ServerResponseHeaderFilter> serverHeaderFilter() {
+    FilterRegistrationBean<ServerResponseHeaderFilter> filter =
+        new FilterRegistrationBean<>(new ServerResponseHeaderFilter());
+    filter.addUrlPatterns("/*");
+    filter.setOrder(SERVER_FILTER_ORDER);
+    return filter;
+  }
 
   @Bean
   ServletRegistrationBean<MetricsServlet> metricsServlet(MetricRegistry registry) {


### PR DESCRIPTION
Motivation:

The `Server` HTTP response header allows the server software to provide the client with information about itself in a somewhat standardised fashion.

We would like the client to know the version of the server, along with some identifier that describes a specific instance of that server.  The latter is to allow the client to identify whether the server has been restarted.

Modification:

Include an additional Servlet Filter that includes the `Server` HTTP response header.  The header value includes the StoRM-WebDAV version and an instance identifier.

The StoRM version is taken from the `Implementation-Version` attribute from the StoRM-WebDAV jar's MANIFEST file, which (in turn) is derived from the version in maven pom.xml file.

The instance identifier is calculated based on the start time of StoRM WebDAV (in milliseconds) truncated to yield 24-bits of entropy.

Result:

StoRM WebDAV HTTP responses now have a `Server` header that describes the StoRM-WebDAV version and provides a simple instance ID.