### PR TITLE
Create GitHub release when tagging a stable version

### DIFF
--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         os: [almalinux]
         version: [8, 9]
+    outputs:
+      repo: ${{ steps.info.outputs.repo }}
+      version: ${{ steps.info.outputs.version }}
     runs-on: ubuntu-latest
     container: '${{ matrix.os }}:${{ matrix.version }}'
     steps:
@@ -27,6 +30,7 @@ jobs:
           path: 'rpmbuild/BUILD'
           fetch-depth: 0
       - name: Calculate version and repo
+        id: info
         run: |
           cd rpmbuild/BUILD
           if [[ ${{ github.ref_type }} = 'tag' ]]; then
@@ -62,7 +66,9 @@ jobs:
             fi
           fi
           echo "REPO=${REPO}" >> "${GITHUB_ENV}"
+          echo "repo=${REPO}" >> "${GITHUB_OUTPUT}"
           echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Version: ${VERSION}"
           echo "Repo: ${REPO:-none}"
       - name: Build RPM
@@ -79,3 +85,22 @@ jobs:
         if: env.REPO != ''
         run: |
           curl --fail --user "${{ vars.NEXUS_USERNAME }}:${{ secrets.NEXUS_PASSWORD }}" --upload-file rpmbuild/RPMS/noarch/*.rpm https://repo.cloud.cnaf.infn.it/repository/storm-rpm-${REPO}/redhat${{ matrix.version }}/
+  create-release:
+    needs: build-rpm
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ needs.build-rpm.outputs.version }}
+    if: needs.build-rpm.outputs.repo == 'stable'
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+      - name: Create release
+        run: |
+          # Get from the changelog file only the part related to the tagged release, in particular:
+          # - Delete lines up to the one beginning with "## <x>.<y>.<z>" (inclusive)
+          # - Delete lines from the next one beginning with "## " until the end of the file
+          # - Change all the "### " to "## " to use heading level 2 instead of level 3
+          sed -e "1,/^## ${VERSION}/d;/^## /,\$d;s/^### /## /g" CHANGELOG.md > RELEASE-CHANGELOG.md
+          gh release create v${VERSION} --title "StoRM WebDAV ${VERSION}" --notes-file RELEASE-CHANGELOG.md build-*/*


### PR DESCRIPTION
In case CHANGELOG.md is not updated to the released version, it leaves the release content unspecified so GitHub fills it with the default value