### PR TITLE
Update Thymeleaf and remove use of class.simpleName in templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,6 @@ SPDX-License-Identifier: Apache-2.0
     <owner-config.version>1.0.12</owner-config.version>
 
     <mock-server.version>5.15.0</mock-server.version>
-
-    <!-- Fixed to 3.1.2 due to https://github.com/thymeleaf/thymeleaf/issues/1027, remove this property after the issue is fixed -->
-    <thymeleaf.version>3.1.2.RELEASE</thymeleaf.version>
   </properties>
 
   <build>

--- a/src/main/java/org/italiangrid/storm/webdav/web/AuthnInfoController.java
+++ b/src/main/java/org/italiangrid/storm/webdav/web/AuthnInfoController.java
@@ -14,6 +14,7 @@ public class AuthnInfoController {
 
   @GetMapping("/authn-info")
   String getAuthenticationInfo(Authentication authentication, Model model) {
+    model.addAttribute("authnSimpleName", authentication.getClass().getSimpleName());
     return "authn-info";
   }
 }

--- a/src/main/resources/templates/authn-info.html
+++ b/src/main/resources/templates/authn-info.html
@@ -14,7 +14,7 @@
       </dd>
       <dt class="col-sm-3">Authentication type</dt>
       <dd class="col-sm-9">
-        <span th:text="${authn.class.simpleName}">OIDCToken</span>
+        <span th:text="${authnSimpleName}">OIDCToken</span>
       </dd>
       <dt class="col-sm-3">Granted authorities</dt>
       <dd class="col-sm-9">

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -25,10 +25,10 @@
         <div class="flex-grow-1">
           <a href="/authn-info" th:text="${authnSubject}">Authenticated user</a>
         </div>
-        <div th:if="${authn != null} and ${authn.class.simpleName} != 'PreAuthenticatedAuthenticationToken'">
+        <div th:if="${authn != null} and ${authn.class.name} != 'org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken'">
           <a th:if="${authnSubject} and ${authnSubject} != 'Anonymous user'" href="/logout">Logout</a>
         </div>
-        <div th:if="${authn != null} and ${authn.class.simpleName} == 'PreAuthenticatedAuthenticationToken' and ${oidcEnabled}">
+        <div th:if="${authn != null} and ${authn.class.name} == 'org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken' and ${oidcEnabled}">
           <a th:if="${authnSubject} and ${authnSubject} != 'Anonymous user'" href="/oidc-login">Login with OIDC</a>
         </div>
       </div>


### PR DESCRIPTION
simpleName can no longer be used directly in templates due to https://github.com/thymeleaf/thymeleaf/issues/1021 released with Thymeleaf 3.1.3