### PR TITLE
Bump VOMS API Java version to 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
     <sonar.organization>italiangrid</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-    <voms-api-java.version>3.3.3</voms-api-java.version>
+    <voms-api-java.version>3.3.4-SNAPSHOT</voms-api-java.version>
     <milton.version>4.0.4.2305</milton.version>
 
     <commons-csv.version>1.14.0</commons-csv.version>
@@ -50,6 +50,20 @@ SPDX-License-Identifier: Apache-2.0
 
     <wiremock.version>3.12.1</wiremock.version>
   </properties>
+
+  <repositories>
+    <repository>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
   <build>
     <finalName>${project.name}</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
     <sonar.organization>italiangrid</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-    <voms-api-java.version>3.3.4-SNAPSHOT</voms-api-java.version>
+    <voms-api-java.version>3.3.4</voms-api-java.version>
     <milton.version>4.0.4.2305</milton.version>
 
     <commons-csv.version>1.14.0</commons-csv.version>


### PR DESCRIPTION
This mainly means CANL v2.7.0, bouncy castle v1.69 and a LSC parser fix.