### PR TITLE
Bump voms-api-java version to 3.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
     <sonar.organization>italiangrid</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-    <voms-api-java.version>3.3.4</voms-api-java.version>
+    <voms-api-java.version>3.3.5-SNAPSHOT</voms-api-java.version>
     <milton.version>4.0.4.2305</milton.version>
 
     <commons-csv.version>1.14.0</commons-csv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
     <sonar.organization>italiangrid</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-    <voms-api-java.version>3.3.5-SNAPSHOT</voms-api-java.version>
+    <voms-api-java.version>3.3.5</voms-api-java.version>
     <milton.version>4.0.4.2305</milton.version>
 
     <commons-csv.version>1.14.0</commons-csv.version>


### PR DESCRIPTION
The VOMS API Java version 3.3.5 uses CANL v2.8.3 and Bouncy Castle v1.80