### PR TITLE
Improve Server HTTP response header logic

### DIFF
--- a/src/main/java/org/italiangrid/storm/webdav/server/servlet/ServerResponseHeaderFilter.java
+++ b/src/main/java/org/italiangrid/storm/webdav/server/servlet/ServerResponseHeaderFilter.java
@@ -4,34 +4,24 @@
 
 package org.italiangrid.storm.webdav.server.servlet;
 
-import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.nio.ByteBuffer;
-import java.security.CodeSource;
-import java.security.ProtectionDomain;
 import java.util.Base64;
 import java.util.Optional;
-import java.util.jar.Attributes;
-import java.util.jar.JarInputStream;
-import java.util.jar.Manifest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * Add 'Server' header response, using StoRM-WebDAV version (taken from the .jar file) and an
  * instance ID that is (with high likelihood) different between any two invocations of StoRM-WebDAV
  * instances.
  */
-public class ServerResponseHeaderFilter implements Filter {
-
-  private static final Logger LOG = LoggerFactory.getLogger(ServerResponseHeaderFilter.class);
+public class ServerResponseHeaderFilter extends OncePerRequestFilter {
 
   private static final int INSTANCE_ID_LENGTH = 4;
 
@@ -39,23 +29,9 @@ public class ServerResponseHeaderFilter implements Filter {
       "StoRM-WebDAV/" + lookupStormVersion() + " (instance=" + calculateInstanceIdentifier() + ")";
 
   private static String lookupStormVersion() {
-    ProtectionDomain pd = ServerResponseHeaderFilter.class.getProtectionDomain();
-    CodeSource cs = pd.getCodeSource();
-    URL u = cs.getLocation();
-
-    Optional<String> maybeVersion = Optional.empty();
-    try (InputStream is = u.openStream();
-        JarInputStream jis = new JarInputStream(is)) {
-      Manifest m = jis.getManifest();
-      if (m != null) {
-        Attributes attributes = m.getMainAttributes();
-        String value = attributes.getValue("Implementation-Version");
-        maybeVersion = Optional.ofNullable(value);
-      }
-    } catch (IOException e) {
-      LOG.warn(e.getMessage(), e);
-    }
-    return maybeVersion.orElse("unknown-version");
+    return Optional.ofNullable(
+            ServerResponseHeaderFilter.class.getPackage().getImplementationVersion())
+        .orElse("unknown-version");
   }
 
   private static String calculateInstanceIdentifier() {
@@ -65,28 +41,26 @@ public class ServerResponseHeaderFilter implements Filter {
     return encoded.substring(encoded.length() - INSTANCE_ID_LENGTH);
   }
 
-  private void specifyServerHeader(HttpServletResponse response) {
-    response.setHeader("Server", SERVER_HEADER_VALUE);
-  }
-
   @Override
-  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+  public void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
       throws IOException, ServletException {
 
-    if (response instanceof HttpServletResponse httpServletResponse) {
-      // Set the header now, in case the response is committed before
-      // chain.doFilter returns.
-      specifyServerHeader(httpServletResponse);
+    response.setHeader(HttpHeaders.SERVER, SERVER_HEADER_VALUE);
+    NoDuplicateServerHeaderResponse wrappedResponse = new NoDuplicateServerHeaderResponse(response);
+
+    chain.doFilter(request, wrappedResponse);
+  }
+
+  private static class NoDuplicateServerHeaderResponse extends HttpServletResponseWrapper {
+    NoDuplicateServerHeaderResponse(HttpServletResponse response) {
+      super(response);
     }
 
-    try {
-      chain.doFilter(request, response);
-    } finally {
-      if (response instanceof HttpServletResponse httpServletResponse) {
-        // Set the header now, in case the response is not yet
-        // committed.  This allows the code to override any
-        // {@literal Server} header value specified earlier.
-        specifyServerHeader(httpServletResponse);
+    @Override
+    public void addHeader(String name, String value) {
+      if (!name.equals(HttpHeaders.SERVER)) {
+        super.addHeader(name, value);
       }
     }
   }


### PR DESCRIPTION
Simplify how StoRM WebDAV version in Server header is obtained
Avoid duplicate Server header: Milton always adds a Server header and nginx complains of the "duplicate header line"